### PR TITLE
Adds a last-build file to the served result, and uses this for more efficient checks for if a scheduled build is needed.

### DIFF
--- a/lib/load-post-files.js
+++ b/lib/load-post-files.js
@@ -7,7 +7,7 @@ import makeSnippet from './make-snippet.js';
 import checkForRubyAnnotations from './check-for-ruby-annotations.js';
 import render from './render.js';
 
-function parseFrontMatter(raw) {
+export function parseFrontMatter(raw) {
   const [, frontMatter, body] = raw.split(/^---/m);
   const filtered = frontMatter.trim()
     .split('\n')


### PR DESCRIPTION
Also avoids rendering posts to get this information. Only the frontmatter is used.