### PR TITLE
Lots of refactoring.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 /* eslint max-lines: off */
 
-import path from 'path';
 import { fileURLToPath } from 'url';
 import { promises as fs } from 'fs';
 import { once } from 'events';
+import getImageSize from 'image-size';
 
 import loadTemplates from './lib/templates.js';
 import { generateMainCss, generateSpecificCss } from './lib/generate-css.js';
@@ -16,10 +16,6 @@ import collateTags from './lib/collate-tags.js';
 import getLastCommitTime from './lib/get-last-commit-time.js';
 import ExecutionGraph from './lib/execution-graph.js';
 
-async function writePublicFile(content, ...pathParts) {
-  await fs.writeFile(path.join(...pathParts), content);
-}
-
 function renderResources({ resources, template, cssPath, baseUrl, dev }) {
   return resources.map(resource => ({
     html: template({ ...resource, cssPath, baseUrl, dev }),
@@ -31,25 +27,23 @@ function makeWriteEntries({ renderedDependencies, pathFragment }) {
   return {
     dependencies: ['paths', renderedDependencies],
     action({ paths: { target }, [renderedDependencies]: rendered }) {
-      return rendered.map(({ html, filename }) => writePublicFile(html, target, pathFragment, filename));
+      return rendered.map(({ html, filename }) => fs.writeFile(new URL(`${pathFragment}/${filename}`, target), html));
     }
   };
 }
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
-
 // This is where it all kicks off. This function loads posts and templates,
 // renders it all to files, and saves them to the public directory.
 export async function build({ baseUrl, baseTitle, dev, syndications }) {
-  const sourcePath = path.join(__dirname, 'src');
-  const contentPath = path.join(__dirname, 'content');
-  const targetPath = path.join(__dirname, 'public');
+  const sourcePath = new URL('./src/', import.meta.url);
+  const contentPath = new URL('./content/', import.meta.url);
+  const targetPath = new URL('./public/', import.meta.url);
 
   let watcher = null;
 
   if (dev) {
     const { watch } = await import('chokidar');
-    watcher = watch([sourcePath, contentPath]);
+    watcher = watch([fileURLToPath(sourcePath), fileURLToPath(contentPath)]);
     await once(watcher, 'ready');
   }
 
@@ -57,13 +51,16 @@ export async function build({ baseUrl, baseTitle, dev, syndications }) {
 
   await graph.addNodes({
     paths: {
-      action() {
+      async action() {
+        await fs.rmdir(targetPath, { recursive: true });
+        await fs.mkdir(targetPath);
+
         return {
           source: sourcePath,
           target: targetPath,
           content: contentPath,
-          async makeDirectory(...pathParts) {
-            const directory = path.join(targetPath, ...pathParts);
+          async makeDirectory(path) {
+            const directory = new URL(path, targetPath);
 
             await fs.rmdir(directory, { recursive: true });
             await fs.mkdir(directory);
@@ -82,7 +79,7 @@ export async function build({ baseUrl, baseTitle, dev, syndications }) {
     templates: {
       dependencies: ['paths'],
       async action({ paths: { source } }) {
-        const templatesPath = path.join(source, 'templates');
+        const templatesPath = new URL('templates/', source);
         const templates = await loadTemplates(templatesPath, { baseTitle });
 
         return ExecutionGraph.createWatchableResult({
@@ -94,7 +91,7 @@ export async function build({ baseUrl, baseTitle, dev, syndications }) {
     feeds: {
       dependencies: ['paths'],
       async action({ paths: { content } }) {
-        const feedsPath = path.join(content, 'feeds.json');
+        const feedsPath = new URL('feeds.json', content);
         const json = await fs.readFile(feedsPath, 'utf8');
 
         return ExecutionGraph.createWatchableResult({
@@ -106,7 +103,7 @@ export async function build({ baseUrl, baseTitle, dev, syndications }) {
     publications: {
       dependencies: ['paths'],
       async action({ paths: { content } }) {
-        const publicationsPath = path.join(content, 'publications.json');
+        const publicationsPath = new URL('publications.json', content);
         const json = await fs.readFile(publicationsPath, 'utf8');
 
         return ExecutionGraph.createWatchableResult({
@@ -118,7 +115,7 @@ export async function build({ baseUrl, baseTitle, dev, syndications }) {
     postFiles: {
       dependencies: ['paths', 'extraCss'],
       async action({ paths: { content }, extraCss }) {
-        const postsPath = path.join(content, 'posts');
+        const postsPath = new URL('posts/', content);
 
         return ExecutionGraph.createWatchableResult({
           path: postsPath,
@@ -129,7 +126,7 @@ export async function build({ baseUrl, baseTitle, dev, syndications }) {
     japaneseNotesFiles: {
       dependencies: ['paths'],
       async action({ paths: { content } }) {
-        const notesPath = path.join(content, 'japanese-notes');
+        const notesPath = new URL('japanese-notes/', content);
 
         return ExecutionGraph.createWatchableResult({
           path: notesPath,
@@ -139,19 +136,19 @@ export async function build({ baseUrl, baseTitle, dev, syndications }) {
     },
     noteFiles: {
       dependencies: ['paths', 'images'],
-      async action({ paths: { content, target } }) {
-        const notesPath = path.join(content, 'notes');
+      async action({ paths: { content }, images: imagesDimensions }) {
+        const notesPath = new URL('notes/', content);
 
         return ExecutionGraph.createWatchableResult({
           path: notesPath,
-          result: await loadNoteFiles(notesPath, syndications, target)
+          result: await loadNoteFiles(notesPath, syndications, imagesDimensions)
         });
       }
     },
     linkFiles: {
       dependencies: ['paths'],
       async action({ paths: { content } }) {
-        const linksPath = path.join(content, 'links');
+        const linksPath = new URL('links/', content);
 
         return ExecutionGraph.createWatchableResult({
           path: linksPath,
@@ -162,7 +159,7 @@ export async function build({ baseUrl, baseTitle, dev, syndications }) {
     likeFiles: {
       dependencies: ['paths'],
       async action({ paths: { content } }) {
-        const likesPath = path.join(content, 'likes');
+        const likesPath = new URL('likes/', content);
 
         return ExecutionGraph.createWatchableResult({
           path: likesPath,
@@ -173,7 +170,7 @@ export async function build({ baseUrl, baseTitle, dev, syndications }) {
     replyFiles: {
       dependencies: ['paths'],
       async action({ paths: { content } }) {
-        const repliesPath = path.join(content, 'replies');
+        const repliesPath = new URL('replies/', content);
 
         return ExecutionGraph.createWatchableResult({
           path: repliesPath,
@@ -181,223 +178,219 @@ export async function build({ baseUrl, baseTitle, dev, syndications }) {
         });
       }
     },
-    publicDirectory: {
+    stylesDirectory: {
       dependencies: ['paths'],
       action({ paths: { makeDirectory } }) {
-        return makeDirectory();
-      }
-    },
-    stylesDirectory: {
-      dependencies: ['paths', 'publicDirectory'],
-      action({ paths: { makeDirectory } }) {
-        return makeDirectory('styles');
+        return makeDirectory('styles/');
       }
     },
     blogDirectory: {
-      dependencies: ['paths', 'publicDirectory'],
+      dependencies: ['paths'],
       action({ paths: { makeDirectory } }) {
-        return makeDirectory('blog');
+        return makeDirectory('blog/');
       }
     },
     japaneseNotesDirectory: {
-      dependencies: ['paths', 'publicDirectory'],
+      dependencies: ['paths'],
       action({ paths: { makeDirectory } }) {
-        return makeDirectory('japanese-notes');
+        return makeDirectory('japanese-notes/');
       }
     },
     notesDirectory: {
-      dependencies: ['paths', 'publicDirectory'],
+      dependencies: ['paths'],
       action({ paths: { makeDirectory } }) {
-        return makeDirectory('notes');
+        return makeDirectory('notes/');
       }
     },
     linksDirectory: {
-      dependencies: ['paths', 'publicDirectory'],
+      dependencies: ['paths'],
       action({ paths: { makeDirectory } }) {
-        return makeDirectory('links');
+        return makeDirectory('links/');
       }
     },
     likesDirectory: {
-      dependencies: ['paths', 'publicDirectory'],
+      dependencies: ['paths'],
       action({ paths: { makeDirectory } }) {
-        return makeDirectory('likes');
+        return makeDirectory('likes/');
       }
     },
     repliesDirectory: {
-      dependencies: ['paths', 'publicDirectory'],
+      dependencies: ['paths'],
       action({ paths: { makeDirectory } }) {
-        return makeDirectory('replies');
+        return makeDirectory('replies/');
       }
     },
     tagsDirectory: {
-      dependencies: ['paths', 'publicDirectory'],
+      dependencies: ['paths'],
       action({ paths: { makeDirectory } }) {
-        return makeDirectory('tags');
+        return makeDirectory('tags/');
       }
     },
     iconsTarget: {
-      dependencies: ['paths', 'publicDirectory'],
+      dependencies: ['paths'],
       async action({ paths: { source, makeDirectory } }) {
         return ExecutionGraph.createWatchableResult({
-          path: path.join(source, 'icons'),
-          result: await makeDirectory('icons')
+          path: new URL('icons/', source),
+          result: await makeDirectory('icons/')
         });
       }
     },
     icons: {
       dependencies: ['paths', 'iconsTarget'],
       async action({ paths: { source }, iconsTarget }) {
-        const directory = path.join(source, 'icons');
+        const directory = new URL('icons/', source);
         const items = (await fs.readdir(directory)).filter(i => i.endsWith('.png') || i.endsWith('.svg'));
 
         await Promise.all(
           items.map(
             item => fs.copyFile(
-              path.join(directory, item),
-              path.join(iconsTarget, item)
+              new URL(item, directory),
+              new URL(item, iconsTarget)
             )
           )
         );
       }
     },
     fontsTarget: {
-      dependencies: ['paths', 'publicDirectory'],
+      dependencies: ['paths'],
       async action({ paths: { source, makeDirectory } }) {
         return ExecutionGraph.createWatchableResult({
-          path: path.join(source, 'fonts'),
-          result: await makeDirectory('fonts')
+          path: new URL('fonts/', source),
+          result: await makeDirectory('fonts/')
         });
       }
     },
     fonts: {
       dependencies: ['paths', 'fontsTarget'],
       async action({ paths: { source }, fontsTarget }) {
-        const directory = path.join(source, 'fonts');
+        const directory = new URL('fonts/', source);
         const items = (await fs.readdir(directory)).filter(i => i.endsWith('.woff') || i.endsWith('.woff2'));
 
         await Promise.all(
           items.map(
             item => fs.copyFile(
-              path.join(directory, item),
-              path.join(fontsTarget, item)
+              new URL(item, directory),
+              new URL(item, fontsTarget)
             )
           )
         );
       }
     },
     imgTarget: {
-      dependencies: ['paths', 'publicDirectory'],
+      dependencies: ['paths'],
       async action({ paths: { source, makeDirectory } }) {
         return ExecutionGraph.createWatchableResult({
-          path: path.join(source, 'img'),
-          result: await makeDirectory('img')
+          path: new URL('img/', source),
+          result: await makeDirectory('img/')
         });
       }
     },
     img: {
       dependencies: ['paths', 'imgTarget'],
       async action({ paths: { source }, imgTarget }) {
-        const directory = path.join(source, 'img');
+        const directory = new URL('img/', source);
         const items = (await fs.readdir(directory)).filter(i => i.endsWith('.jpg'));
 
         await Promise.all(
           items.map(
             item => fs.copyFile(
-              path.join(directory, item),
-              path.join(imgTarget, item)
+              new URL(item, directory),
+              new URL(item, imgTarget)
             )
           )
         );
       }
     },
     scriptsTarget: {
-      dependencies: ['paths', 'publicDirectory'],
+      dependencies: ['paths'],
       async action({ paths: { source, makeDirectory } }) {
         return ExecutionGraph.createWatchableResult({
-          path: path.join(source, 'scripts'),
-          result: await makeDirectory('scripts')
+          path: new URL('scripts/', source),
+          result: await makeDirectory('scripts/')
         });
       }
     },
     scripts: {
       dependencies: ['paths', 'scriptsTarget'],
       async action({ paths: { content }, scriptsTarget }) {
-        const directory = path.join(content, 'scripts');
+        const directory = new URL('scripts/', content);
         const items = (await fs.readdir(directory)).filter(i => i.endsWith('.js'));
 
         await Promise.all(
           items.map(
             item => fs.copyFile(
-              path.join(directory, item),
-              path.join(scriptsTarget, item)
+              new URL(item, directory),
+              new URL(item, scriptsTarget)
             )
           )
         );
       }
     },
     papersTarget: {
-      dependencies: ['paths', 'publicDirectory'],
+      dependencies: ['paths'],
       async action({ paths: { source, makeDirectory } }) {
         return ExecutionGraph.createWatchableResult({
-          path: path.join(source, 'papers'),
-          result: await makeDirectory('papers')
+          path: new URL('papers/', source),
+          result: await makeDirectory('papers/')
         });
       }
     },
     papers: {
       dependencies: ['paths', 'papersTarget'],
       async action({ paths: { content }, papersTarget }) {
-        const directory = path.join(content, 'papers');
+        const directory = new URL('papers/', content);
         const items = (await fs.readdir(directory)).filter(i => i.endsWith('.pdf'));
 
         await Promise.all(
           items.map(
             item => fs.copyFile(
-              path.join(directory, item),
-              path.join(papersTarget, item)
+              new URL(item, directory),
+              new URL(item, papersTarget)
             )
           )
         );
       }
     },
     imagesTarget: {
-      dependencies: ['paths', 'publicDirectory'],
+      dependencies: ['paths'],
       async action({ paths: { source, makeDirectory } }) {
         return ExecutionGraph.createWatchableResult({
-          path: path.join(source, 'images'),
-          result: await makeDirectory('images')
+          path: new URL('images/', source),
+          result: await makeDirectory('images/')
         });
       }
     },
     images: {
       dependencies: ['paths', 'imagesTarget'],
       async action({ paths: { content }, imagesTarget }) {
-        const directory = path.join(content, 'images');
+        const directory = new URL('images/', content);
         const items = (await fs.readdir(directory)).filter(i => !i.startsWith('.'));
 
-        await Promise.all(
-          items.map(
-            item => fs.copyFile(
-              path.join(directory, item),
-              path.join(imagesTarget, item)
-            )
-          )
-        );
+        return new Map(await Promise.all(
+          items.map(async item => {
+            const sourceFile = await fs.readFile(new URL(item, directory));
+            const dims = await getImageSize(sourceFile);
+
+            await fs.writeFile(new URL(item, imagesTarget), sourceFile);
+
+            return [`/images/${item}`, dims];
+          })
+        ));
       }
     },
     googleSiteVerification: {
-      dependencies: ['paths', 'publicDirectory'],
+      dependencies: ['paths'],
       action({ paths: { target } }) {
         const name = 'google91826e4f943d9ee9.html';
-        return fs.writeFile(path.join(target, name), `google-site-verification: ${name}\n`);
+        return fs.writeFile(new URL(name, target), `google-site-verification: ${name}\n`);
       }
     },
     keybaseVerification: {
-      dependencies: ['paths', 'publicDirectory'],
+      dependencies: ['paths'],
       async action({ paths: { source, target } }) {
-        const verificationPath = path.join(source, 'keybase.txt');
+        const verificationPath = new URL('keybase.txt', source);
 
-        await fs.copyFile(verificationPath, path.join(target, 'keybase.txt'));
+        await fs.copyFile(verificationPath, new URL('keybase.txt', target));
 
         return ExecutionGraph.createWatchableResult({
           path: verificationPath,
@@ -406,11 +399,11 @@ export async function build({ baseUrl, baseTitle, dev, syndications }) {
       }
     },
     robotsFile: {
-      dependencies: ['paths', 'publicDirectory'],
+      dependencies: ['paths'],
       async action({ paths: { source, target } }) {
-        const verificationPath = path.join(source, 'robots.txt');
+        const verificationPath = new URL('robots.txt', source);
 
-        await fs.copyFile(verificationPath, path.join(target, 'robots.txt'));
+        await fs.copyFile(verificationPath, new URL('robots.txt', target));
 
         return ExecutionGraph.createWatchableResult({
           path: verificationPath,
@@ -419,59 +412,57 @@ export async function build({ baseUrl, baseTitle, dev, syndications }) {
       }
     },
     indexJsFile: {
-      dependencies: ['paths', 'publicDirectory'],
+      dependencies: ['paths'],
       async action({ paths: { source, target } }) {
-        const verificationPath = path.join(source, 'index.js');
+        const indexPath = new URL('index.js', source);
 
-        await fs.copyFile(verificationPath, path.join(target, 'index.js'));
+        await fs.copyFile(indexPath, new URL('index.js', target));
 
         return ExecutionGraph.createWatchableResult({
-          path: verificationPath,
+          path: indexPath,
           result: null
         });
       }
     },
     serviceWorkerFile: {
-      dependencies: ['paths', 'publicDirectory'],
+      dependencies: ['paths'],
       async action({ paths: { source, target } }) {
-        const verificationPath = path.join(source, 'sw.js');
+        const swPath = new URL('sw.js', source);
 
-        await fs.copyFile(verificationPath, path.join(target, 'sw.js'));
+        await fs.copyFile(swPath, new URL('sw.js', target));
 
         return ExecutionGraph.createWatchableResult({
-          path: verificationPath,
+          path: swPath,
           result: null
         });
       }
     },
     manifestFile: {
-      dependencies: ['paths', 'publicDirectory'],
+      dependencies: ['paths'],
       async action({ paths: { source, target } }) {
-        const verificationPath = path.join(source, 'manifest.json');
+        const manifestPath = new URL('manifest.json', source);
 
-        await fs.copyFile(verificationPath, path.join(target, 'manifest.json'));
+        await fs.copyFile(manifestPath, new URL('manifest.json', target));
 
         return ExecutionGraph.createWatchableResult({
-          path: verificationPath,
+          path: manifestPath,
           result: null
         });
       }
     },
     css: {
-      dependencies: ['paths', 'publicDirectory'],
+      dependencies: ['paths'],
       async action({ paths: { source, target } }) {
-        const cssPath = path.join(source, 'css');
-
         return ExecutionGraph.createWatchableResult({
-          path: cssPath,
-          result: await generateMainCss(cssPath, target, 'entry.css', 'default')
+          path: new URL('css/', source),
+          result: await generateMainCss(new URL('css/entry.css', source), target, 'default')
         });
       }
     },
     extraCss: {
       dependencies: ['paths', 'stylesDirectory'],
       async action({ paths: { content }, stylesDirectory }) {
-        const cssPath = path.join(content, 'styles');
+        const cssPath = new URL('styles/', content);
 
         return ExecutionGraph.createWatchableResult({
           path: cssPath,
@@ -517,7 +508,7 @@ export async function build({ baseUrl, baseTitle, dev, syndications }) {
     },
     renderedReplies: {
       dependencies: ['css', 'templates', 'replyFiles'],
-      action({ replyFiles: resources, templates: { replies: template }, css: cssPath }) {
+      action({ replyFiles: resources, templates: { reply: template }, css: cssPath }) {
         return renderResources({ resources, template, cssPath, baseUrl, dev });
       }
     },
@@ -667,98 +658,96 @@ export async function build({ baseUrl, baseTitle, dev, syndications }) {
     writtenIndex: {
       dependencies: ['paths', 'renderedAbout'],
       action({ paths: { target }, renderedAbout }) {
-        writePublicFile(renderedAbout, target, 'index.html');
+        return fs.writeFile(new URL('index.html', target), renderedAbout);
       }
     },
     writtenBlogIndex: {
       dependencies: ['paths', 'renderedBlogIndex'],
       action({ paths: { target }, renderedBlogIndex }) {
-        return writePublicFile(renderedBlogIndex, target, 'blog', 'index.html');
+        return fs.writeFile(new URL('blog/index.html', target), renderedBlogIndex);
       }
     },
     writtenJapaneseNotesIndex: {
       dependencies: ['paths', 'renderedJapaneseNotesIndex'],
       action({ paths: { target }, renderedJapaneseNotesIndex }) {
-        return writePublicFile(renderedJapaneseNotesIndex, target, 'japanese-notes', 'index.html');
+        return fs.writeFile(new URL('japanese-notes/index.html', target), renderedJapaneseNotesIndex);
       }
     },
     writtenNotesIndex: {
       dependencies: ['paths', 'renderedNotesIndex'],
       action({ paths: { target }, renderedNotesIndex }) {
-        return writePublicFile(renderedNotesIndex, target, 'notes', 'index.html');
+        return fs.writeFile(new URL('notes/index.html', target), renderedNotesIndex);
       }
     },
     writtenLinksIndex: {
       dependencies: ['paths', 'renderedLinksIndex'],
       action({ paths: { target }, renderedLinksIndex }) {
-        return writePublicFile(renderedLinksIndex, target, 'links', 'index.html');
+        return fs.writeFile(new URL('links/index.html', target), renderedLinksIndex);
       }
     },
     writtenLikesIndex: {
       dependencies: ['paths', 'renderedLikesIndex'],
       action({ paths: { target }, renderedLikesIndex }) {
-        return writePublicFile(renderedLikesIndex, target, 'likes', 'index.html');
+        return fs.writeFile(new URL('likes/index.html', target), renderedLikesIndex);
       }
     },
     writtenRepliesIndex: {
       dependencies: ['paths', 'renderedRepliesIndex'],
       action({ paths: { target }, renderedRepliesIndex }) {
-        return writePublicFile(renderedRepliesIndex, target, 'replies', 'index.html');
+        return fs.writeFile(new URL('replies/index.html', target), renderedRepliesIndex);
       }
     },
     writtenPublications: {
       dependencies: ['paths', 'renderedPublications'],
       action({ paths: { target }, renderedPublications }) {
-        return writePublicFile(renderedPublications, target, 'publications.html');
+        return fs.writeFile(new URL('publications.html', target), renderedPublications);
       }
     },
     writtenWebmentionConfirmation: {
       dependencies: ['paths', 'renderedWebmentionConfirmation'],
       action({ paths: { target }, renderedWebmentionConfirmation }) {
-        return writePublicFile(renderedWebmentionConfirmation, target, 'webmention.html');
+        return fs.writeFile(new URL('webmention.html', target), renderedWebmentionConfirmation);
       }
     },
     writtenFourOhFour: {
       dependencies: ['paths', 'renderedFourOhFour'],
       action({ paths: { target }, renderedFourOhFour }) {
-        return writePublicFile(renderedFourOhFour, target, '404.html');
+        return fs.writeFile(new URL('404.html', target), renderedFourOhFour);
       }
     },
     writtenSitemap: {
       dependencies: ['paths', 'renderedSitemap'],
       action({ paths: { target }, renderedSitemap }) {
-        return writePublicFile(renderedSitemap, target, 'sitemap.txt');
+        return fs.writeFile(new URL('sitemap.txt', target), renderedSitemap);
       }
     },
     writtenAtomFeeds: {
       dependencies: ['paths', 'renderedAtomFeeds'],
       action({ paths: { target }, renderedAtomFeeds: { all, posts, social } }) {
         return Promise.all([
-          writePublicFile(all, target, 'atom.xml'),
-          writePublicFile(posts, target, 'blog.atom.xml'),
-          writePublicFile(social, target, 'social.atom.xml')
+          fs.writeFile(new URL('atom.xml', target), all),
+          fs.writeFile(new URL('blog.atom.xml', target), posts),
+          fs.writeFile(new URL('social.atom.xml', target), social)
         ]);
       }
     },
     writtenOpml: {
       dependencies: ['paths', 'templates', 'feeds'],
       action({ paths: { target }, templates, feeds }) {
-        const content = templates.feeds({ feeds });
-        return writePublicFile(content, target, 'feeds.opml');
+        return fs.writeFile(new URL('feeds.opml', target), templates.feeds({ feeds }));
       }
     },
     writtenBlogroll: {
       dependencies: ['css', 'paths', 'templates', 'feeds'],
       action({ css: cssPath, paths: { target }, templates, feeds }) {
-        const content = templates.blogroll({
+        return fs.writeFile(new URL('blogroll.html', target), templates.blogroll({
           feeds,
           cssPath,
           dev,
           baseUrl,
           localUrl: '/blogroll',
           title: 'Blogroll'
-        });
-        return writePublicFile(content, target, 'blogroll.html');
+        }));
       }
     },
     writtenPosts: makeWriteEntries({ renderedDependencies: 'renderedPosts', pathFragment: 'blog' }),
@@ -769,9 +758,9 @@ export async function build({ baseUrl, baseTitle, dev, syndications }) {
     writtenReplies: makeWriteEntries({ renderedDependencies: 'renderedReplies', pathFragment: 'replies' }),
     writtenTags: makeWriteEntries({ renderedDependencies: 'collatedTags', pathFragment: 'tags' }),
     lastBuild: {
-      dependencies: ['publicDirectory', 'writtenSitemap'],
-      action({ publicDirectory }) {
-        return fs.writeFile(path.join(publicDirectory, 'last-build.txt'), `${new Date().toISOString()}\n`);
+      dependencies: ['paths', 'writtenSitemap'],
+      action({ paths: { target } }) {
+        return fs.writeFile(new URL('last-build.txt', target), `${new Date().toISOString()}\n`);
       }
     }
   });

--- a/lib/execution-graph.js
+++ b/lib/execution-graph.js
@@ -1,4 +1,5 @@
 import { EventEmitter, once } from 'events';
+import { pathToFileURL } from 'url';
 
 async function waitForDependencies(executionGraph, dependencies) {
   const results = {};
@@ -20,8 +21,10 @@ async function watchForChanges(watcher, graph) {
   try {
     const [, pathStr] = await once(watcher, 'all');
 
+    const url = pathToFileURL(pathStr);
+
     for (const [name, { watchPath }] of graph.nodes) {
-      if (watchPath && pathStr.startsWith(watchPath)) {
+      if (watchPath && url.href.startsWith(watchPath)) {
         console.time(`Build succeeded for ${name}`); // eslint-disable-line no-console
         console.log('Rerunning Node:', name); // eslint-disable-line no-console
         graph.rerunNode({ name });

--- a/lib/generate-css.js
+++ b/lib/generate-css.js
@@ -7,13 +7,13 @@ import postCssCalc from 'postcss-calc';
 import customProperties from 'postcss-custom-properties';
 import cssnano from 'cssnano';
 
-async function renderCss(paths) {
+async function renderCss(paths, dev) {
   const { css } = await postcss([
     postcssImport(),
     postCssPresetEnv(),
     customProperties({ preserve: true }),
     postCssCalc(),
-    cssnano({ preset: 'default' })
+    ...(dev ? [] : [cssnano({ preset: 'default' })])
   ]).process(
     paths.map(p => `@import url('${p.pathname}');`).join('\n'),
     { from: undefined }
@@ -27,7 +27,7 @@ async function renderCss(paths) {
   return { content: css, hash };
 }
 
-export async function generateSpecificCss(directory, targetDirectory) {
+export async function generateSpecificCss(directory, targetDirectory, dev) {
   const dir = await fs.readdir(directory);
 
   const mapEntries = await Promise.all(dir.map(async filename => {
@@ -36,7 +36,7 @@ export async function generateSpecificCss(directory, targetDirectory) {
     }
 
     const entryFile = new URL(filename, directory);
-    const { content, hash } = await renderCss([entryFile]);
+    const { content, hash } = await renderCss([entryFile], dev);
 
     const hashedFilename = `${filename.slice(0, -4)}-${hash}.css`;
     const cssPath = new URL(hashedFilename, targetDirectory);
@@ -50,15 +50,18 @@ export async function generateSpecificCss(directory, targetDirectory) {
 }
 
 // Compiles and calculates a unique filename for CSS.
-export async function generateMainCss(entry, targetDirectory, codeStyle = 'default') {
+export async function generateMainCss({ entry, targetDirectory, codeStyle = 'default', dev }) {
   const codeStyleFile = new URL(`../node_modules/highlight.js/styles/${codeStyle}.css`, import.meta.url);
 
-  const { content, hash } = await renderCss([entry, codeStyleFile]);
+  const { content, hash } = await renderCss([entry, codeStyleFile], dev);
 
   const hashedFilename = `main-${hash}.css`;
-  const cssPath = new URL(hashedFilename, targetDirectory);
+  const cssUrl = new URL(hashedFilename, targetDirectory);
 
-  await fs.writeFile(cssPath, content);
+  await fs.writeFile(cssUrl, content);
 
-  return `/${hashedFilename}`;
+  return {
+    url: cssUrl,
+    htmlPath: `/${hashedFilename}`
+  };
 }

--- a/lib/generate-css.js
+++ b/lib/generate-css.js
@@ -6,18 +6,16 @@ import postCssPresetEnv from 'postcss-preset-env';
 import postCssCalc from 'postcss-calc';
 import customProperties from 'postcss-custom-properties';
 import cssnano from 'cssnano';
-import path from 'path';
-import { fileURLToPath } from 'url';
 
-async function renderCss(directory, paths) {
+async function renderCss(paths) {
   const { css } = await postcss([
-    postcssImport({ path: directory }),
+    postcssImport(),
     postCssPresetEnv(),
     customProperties({ preserve: true }),
     postCssCalc(),
     cssnano({ preset: 'default' })
   ]).process(
-    paths.map(p => `@import url('${p}');`).join('\n'),
+    paths.map(p => `@import url('${p.pathname}');`).join('\n'),
     { from: undefined }
   );
 
@@ -37,10 +35,11 @@ export async function generateSpecificCss(directory, targetDirectory) {
       return null;
     }
 
-    const { content, hash } = await renderCss(directory, [path.join(directory, filename)]);
+    const entryFile = new URL(filename, directory);
+    const { content, hash } = await renderCss([entryFile]);
 
     const hashedFilename = `${filename.slice(0, -4)}-${hash}.css`;
-    const cssPath = path.join(targetDirectory, hashedFilename);
+    const cssPath = new URL(hashedFilename, targetDirectory);
 
     await fs.writeFile(cssPath, content);
 
@@ -51,13 +50,13 @@ export async function generateSpecificCss(directory, targetDirectory) {
 }
 
 // Compiles and calculates a unique filename for CSS.
-export async function generateMainCss(directory, targetDirectory, filename, codeStyle = 'default') {
-  const codeStyleFile = fileURLToPath(new URL(`../node_modules/highlight.js/styles/${codeStyle}.css`, import.meta.url));
+export async function generateMainCss(entry, targetDirectory, codeStyle = 'default') {
+  const codeStyleFile = new URL(`../node_modules/highlight.js/styles/${codeStyle}.css`, import.meta.url);
 
-  const { content, hash } = await renderCss(directory, [filename, codeStyleFile]);
+  const { content, hash } = await renderCss([entry, codeStyleFile]);
 
   const hashedFilename = `main-${hash}.css`;
-  const cssPath = path.join(targetDirectory, hashedFilename);
+  const cssPath = new URL(hashedFilename, targetDirectory);
 
   await fs.writeFile(cssPath, content);
 

--- a/lib/get-last-commit-time.js
+++ b/lib/get-last-commit-time.js
@@ -1,10 +1,11 @@
 import { promisify } from 'util';
 import { exec } from 'child_process';
+import { fileURLToPath } from 'url';
 
 const pexec = promisify(exec);
 
 export default async function getLastPostCommitTime(dir) {
-  const { stdout, stderr } = await pexec(`git log -1 --format=%ct ${dir}`);
+  const { stdout, stderr } = await pexec(`git log -1 --format=%ct ${fileURLToPath(dir)}`);
 
   if (stderr) {
     throw new Error(`Error from exec: ${stderr}`);

--- a/lib/load-like-files.js
+++ b/lib/load-like-files.js
@@ -1,5 +1,4 @@
 import { promises as fs } from 'fs';
-import path from 'path';
 import handlebars from 'handlebars';
 
 const makeSnippet = handlebars
@@ -8,7 +7,7 @@ const makeSnippet = handlebars
 export default async function loadLikeFiles(dir) {
   const filenames = await fs.readdir(dir);
   const notes = await Promise.all(filenames.filter(fn => fn.endsWith('.json')).map(async filename => {
-    const note = await fs.readFile(path.join(dir, filename), 'utf8');
+    const note = await fs.readFile(new URL(filename, dir), 'utf8');
     const { properties: { 'like-of': [likeOf] } } = JSON.parse(note);
     const timestamp = parseInt(filename, 10);
 

--- a/lib/load-link-files.js
+++ b/lib/load-link-files.js
@@ -1,5 +1,4 @@
 import { promises as fs } from 'fs';
-import path from 'path';
 import handlebars from 'handlebars';
 
 const makeSnippet = handlebars
@@ -8,7 +7,7 @@ const makeSnippet = handlebars
 export default async function loadLinkFiles(dir, syndications) {
   const filenames = await fs.readdir(dir);
   const notes = await Promise.all(filenames.filter(fn => fn.endsWith('.json')).map(async filename => {
-    const link = await fs.readFile(path.join(dir, filename), 'utf8');
+    const link = await fs.readFile(new URL(filename, dir), 'utf8');
     const {
       properties: {
         'bookmark-of': bookmarkOf = [],

--- a/lib/load-note-files.js
+++ b/lib/load-note-files.js
@@ -1,25 +1,23 @@
 import { promises as fs } from 'fs';
-import path from 'path';
 import handlebars from 'handlebars';
-import imageSize from 'image-size';
 
 const makeSnippet = handlebars.compile('<p class="p-summary">{{content}}</p>');
 
-export default async function loadNoteFiles(dir, syndications, publicDirectory) {
+export default async function loadNoteFiles(dir, syndications, imagesDimensions) {
   const filenames = await fs.readdir(dir);
   const notes = await Promise.all(filenames.filter(fn => fn.endsWith('.json')).map(async (filename, index) => {
-    const note = await fs.readFile(path.join(dir, filename), 'utf8');
+    const note = await fs.readFile(new URL(filename, dir), 'utf8');
     const { properties: { content: [content], photo, 'mp-syndicate-to': rawSyndications } } = JSON.parse(note);
     const timestamp = parseInt(filename, 10);
     const filteredSyndications = [].concat(rawSyndications).filter(Boolean);
 
     const photos = (photo || []).map(p => typeof p === 'string' ? { value: p, alt: content } : p);
 
-    await Promise.all(photos.map(async photo => {
-      const { width, height } = await imageSize(path.join(publicDirectory, photo.value));
+    for (const photo of photos) {
+      const { width, height } = imagesDimensions.get(photo.value);
       photo.width = width;
       photo.height = height;
-    }));
+    }
 
     return {
       timestamp,

--- a/lib/load-post-files.js
+++ b/lib/load-post-files.js
@@ -1,5 +1,4 @@
 import { promises as fs } from 'fs';
-import { join } from 'path';
 import { JSDOM } from 'jsdom';
 
 import createSlug from './create-slug.js';
@@ -19,16 +18,16 @@ export function parseFrontMatter(raw) {
 
 const cache = new Map();
 
-async function loadPostFile(filePath, baseUrl, type, extraCss) {
-  const { mtimeMs } = await fs.stat(filePath, { bigint: true });
-  const cached = cache.get(filePath);
+async function loadPostFile(fileUrl, baseUrl, type, extraCss) {
+  const { mtimeMs } = await fs.stat(fileUrl, { bigint: true });
+  const cached = cache.get(fileUrl);
   const extraCssPaths = new Set(extraCss ? extraCss.values() : []);
 
   if (cached && cached.mtimeMs === mtimeMs && cached.styles.every(s => extraCssPaths.has(s.src))) {
     return cached;
   }
 
-  const post = await fs.readFile(filePath, 'utf8');
+  const post = await fs.readFile(fileUrl, 'utf8');
   const { attributes, body } = parseFrontMatter(post);
   const { title, datetime, updated, tags, webmentions, draft, description, scripts = [], styles = [] } = attributes;
   const slug = attributes.slug || createSlug(title);
@@ -64,7 +63,7 @@ async function loadPostFile(filePath, baseUrl, type, extraCss) {
     type: 'blog'
   };
 
-  cache.set(filePath, digested);
+  cache.set(fileUrl, digested);
 
   return digested;
 }
@@ -72,7 +71,7 @@ async function loadPostFile(filePath, baseUrl, type, extraCss) {
 // Loads post source and metadata.
 export default async function loadPostFiles({ path, baseUrl, type = 'blog', extraCss = new Map() }) {
   const filenames = await fs.readdir(path);
-  const posts = await Promise.all(filenames.map(fn => loadPostFile(join(path, fn), baseUrl, type, extraCss)));
+  const posts = await Promise.all(filenames.map(fn => loadPostFile(new URL(fn, path), baseUrl, type, extraCss)));
   const now = Date.now();
 
   return posts

--- a/lib/load-reply-files.js
+++ b/lib/load-reply-files.js
@@ -1,5 +1,4 @@
 import { promises as fs } from 'fs';
-import path from 'path';
 import handlebars from 'handlebars';
 
 const makeSnippet = handlebars.compile('<p>{{content}}</p>');
@@ -7,7 +6,7 @@ const makeSnippet = handlebars.compile('<p>{{content}}</p>');
 export default async function loadReplyFiles(dir) {
   const filenames = await fs.readdir(dir);
   const notes = await Promise.all(filenames.filter(fn => fn.endsWith('.json')).map(async filename => {
-    const note = await fs.readFile(path.join(dir, filename), 'utf8');
+    const note = await fs.readFile(new URL(filename, dir), 'utf8');
     const { properties: { content: [content], 'in-reply-to': [inReplyTo] } } = JSON.parse(note);
     const timestamp = parseInt(filename, 10);
 

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -1,6 +1,5 @@
 import handlebars from 'handlebars';
 import { promises as fs } from 'fs';
-import path from 'path';
 
 // A helper to turn a datetime into a human readable string.
 handlebars.registerHelper('humanDate', datetime => new Date(datetime).toDateString());
@@ -47,8 +46,8 @@ handlebars.registerHelper('lightEmoji', makePicker(['🌴', '☀️', '🕶', '�
 handlebars.registerHelper('darkEmoji', makePicker(['⭐️', '🌙', '🍹', '🌴', '🎷']));
 
 async function getTemplateAndName(directory, filename) {
-  const source = await fs.readFile(path.join(directory, filename), 'utf8');
-  const { name } = path.parse(filename.slice(0, -('.handlebars'.length)));
+  const source = await fs.readFile(new URL(filename, directory), 'utf8');
+  const name = filename.slice(0, filename.lastIndexOf('.', filename.length - 12)); // trim off .ext.handlebars
 
   return [name, source.trim()];
 }
@@ -56,8 +55,8 @@ async function getTemplateAndName(directory, filename) {
 export default async function loadTemplates(dir, { baseTitle }) {
   handlebars.registerHelper('baseTitle', () => baseTitle);
 
-  const partialsPath = path.join(dir, 'partials');
-  const templatesPath = path.join(dir, 'documents');
+  const partialsPath = new URL('partials/', dir);
+  const templatesPath = new URL('documents/', dir);
   const templates = {};
 
   const [documentsSources] = await Promise.all([

--- a/scripts/serve.js
+++ b/scripts/serve.js
@@ -3,19 +3,13 @@
 import { createReadStream } from 'fs';
 import { once } from 'events';
 import http from 'http';
-import path from 'path';
-import url from 'url';
 
 import Toisu from 'toisu';
 import serveStatic from 'toisu-static';
-import chokidar from 'chokidar';
 
 import { build } from '../index.js';
 
-const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
-const notFoundPath = path.join(__dirname, '..', 'public', '404.html');
-const sourcePath = path.join(__dirname, '..', 'src');
-const contentPath = path.join(__dirname, '..', 'content');
+const notFoundUrl = new URL('../public/404.html', import.meta.url);
 const port = 8080;
 const syndications = {
   mastodon: 'https://mastodon.social/@qubyte',
@@ -24,9 +18,8 @@ const syndications = {
 
 // This watches the content of the src directory for any changes, triggering a
 // build each time a change happens.
-const watcher = chokidar.watch([sourcePath, contentPath]);
 
-once(watcher, 'ready').then(async () => {
+(async () => {
   console.log('No event or path, or a source file changed. Running initial build...');
   console.time('Initial build');
 
@@ -36,7 +29,8 @@ once(watcher, 'ready').then(async () => {
     graph = await build({
       baseUrl: `http://localhost:${port}`,
       baseTitle: 'DEV MODE',
-      syndications, dev: true
+      syndications,
+      dev: true
     });
   } catch (error) {
     console.error(error.stack);
@@ -87,10 +81,10 @@ once(watcher, 'ready').then(async () => {
 
   // This middleware handles everything not handled before it (404).
   app.use((_req, res) => {
-    createReadStream(notFoundPath).pipe(res.writeHead(404, { 'Content-Type': 'text/html; charset=UTF-8' }));
+    createReadStream(notFoundUrl).pipe(res.writeHead(404, { 'Content-Type': 'text/html; charset=UTF-8' }));
   });
 
   http
     .createServer(app.requestHandler)
     .listen(port, () => console.log(`listening on http://localhost:${port}`));
-});
+})();


### PR DESCRIPTION
- Replaces old paths with file URLs where possible.
- Removes redundant watcher from serve script.
- Calculates image sizes upon copy.
- Moves public directory creation into the paths node.