### PR TITLE
Adds backlinks for posts and japanese notes.

### DIFF
--- a/lib/get-local-links.js
+++ b/lib/get-local-links.js
@@ -1,0 +1,13 @@
+export default function getLocalLinks(document, fromUrl, baseUrl) {
+  const localLinks = new Set();
+
+  for (const { href } of document.querySelectorAll('a')) {
+    const normalized = new URL(href, fromUrl);
+
+    if (normalized.href.startsWith(baseUrl)) {
+      localLinks.add(normalized.pathname);
+    }
+  }
+
+  return localLinks;
+}

--- a/lib/load-post-files.js
+++ b/lib/load-post-files.js
@@ -5,6 +5,7 @@ import createSlug from './create-slug.js';
 import makeSnippet from './make-snippet.js';
 import checkForRubyAnnotations from './check-for-ruby-annotations.js';
 import render from './render.js';
+import getLocalLinks from './get-local-links.js';
 
 export function parseFrontMatter(raw) {
   const [, frontMatter, body] = raw.split(/^---/m);
@@ -35,6 +36,9 @@ async function loadPostFile(fileUrl, baseUrl, type, extraCss) {
   const content = await render(body);
   const { document } = new JSDOM(content).window;
   const hasRuby = checkForRubyAnnotations(document);
+  const localUrl = `/${type}/${slug}`;
+  const canonical = `${baseUrl}${localUrl}`;
+  const localLinks = getLocalLinks(document, canonical, baseUrl);
 
   const digested = {
     mtimeMs,
@@ -51,8 +55,9 @@ async function loadPostFile(fileUrl, baseUrl, type, extraCss) {
     isBlogEntry: true,
     draft,
     slug,
-    localUrl: `/${type}/${slug}`,
-    canonical: `${baseUrl}/${type}/${slug}`,
+    localUrl,
+    canonical,
+    localLinks,
     filename: `${slug}.html`,
     mastodonHandle: '@qubyte@mastodon.social',
     title,

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,6 +1,6 @@
 import { build } from '../index.js';
 
-const baseUrl = process.env.URL;
+const baseUrl = process.env.CONTEXT !== 'production' ? process.env.DEPLOY_URL : process.env.URL;
 const baseTitle = process.env.BASE_TITLE;
 const syndications = {
   mastodon: process.env.MASTODON_SYNDICATION,

--- a/src/templates/documents/blog.html.handlebars
+++ b/src/templates/documents/blog.html.handlebars
@@ -16,6 +16,7 @@
       <div class="e-content">
         {{{content}}}
       </div>
+      {{> backlinks }}
       {{> webmentions }}
       <details class="share">
         <summary>Feel like sharing or responding?</summary>

--- a/src/templates/partials/backlinks.html.handlebars
+++ b/src/templates/partials/backlinks.html.handlebars
@@ -1,0 +1,10 @@
+{{#if backlinks}}
+<section>
+  <h3>Backlinks</h3>
+  <ul>
+    {{#backlinks}}
+    <li><a class="backlink" href="{{href}}">{{title}}</a></li>
+    {{/backlinks}}
+  </ul>
+</section>
+{{/if}}


### PR DESCRIPTION
When post and note files link to each other, their distinations will list these as backlinks. The intent is to make posts and notes more capable if / when I choose to use my blog more as a garden or zettelkasten.

I've also tacked on a commit to fix how links are built in previews vs production.