### PR TITLE
Rubies revised

### DIFF
--- a/content/japanese-notes/ability-to-do.md
+++ b/content/japanese-notes/ability-to-do.md
@@ -12,30 +12,30 @@ There are two major ways of expressing the ability to do something.
 
 A verb in the [potential form](potential-form) directly expresses ability:
 
-- <span lang="ja">[食,た](r)べる</span>: to eat
-- <span lang="ja">[食,た](r)べられる</span>: to be able to eat
+- <span lang="ja">^食,た^べる</span>: to eat
+- <span lang="ja">^食,た^べられる</span>: to be able to eat
 
-## Using <span lang="ja">[出,で,来,き](r)る</span>
+## Using <span lang="ja">^出,で,来,き^る</span>
 
 This pattern seems to be used in a more general sense of possibility rather than
 for particular events or peeople etc., though I'm not advanced enough to have a
 feel for it.
 
 The general pattern is to add
-<span lang="ja">[事,こと](r)が[出,で,来,き](r)る</span> to a verb in the dictionary
+<span lang="ja">^事,こと^が^出,で,来,き^る</span> to a verb in the dictionary
 form.
 
-- <span lang="ja">[食,た](r)べる</span>: to eat
-- <span lang="ja">[食,た](r)べる[事,こと](r)が[出,で,来,き](r)る</span>: to be able to eat
+- <span lang="ja">^食,た^べる</span>: to eat
+- <span lang="ja">^食,た^べる^事,こと^が^出,で,来,き^る</span>: to be able to eat
 
 For <span lang="ja">する</span> verbs this pattern can be added directly to the
 noun:
 
 - <span lang="ja">テニスをする</span>: to play tennis
-- <span lang="ja">テニス[事,こと](r)が[出,で,来,き](r)る</span>: to be able to play tennis
+- <span lang="ja">テニス^事,こと^が^出,で,来,き^る</span>: to be able to play tennis
 
 This fries my brain a bit when I remember that
-<span lang="ja">[出,で,来,き](r)る</span> is already the (irregular) potential
+<span lang="ja">^出,で,来,き^る</span> is already the (irregular) potential
 form of <span lang="ja">する</span>.
 
 Remember, when in the negative form the <span lang="ja">が</span> may become a

--- a/content/japanese-notes/before-and-after.md
+++ b/content/japanese-notes/before-and-after.md
@@ -14,17 +14,17 @@ translation which feels a bit more natural to me without changing the meaning).
 
 A list of actions can be given in sequence.
 
-- <span lang="ja">[公,こう,園,えん](r)に[行,い](r)==って==[遊,あそ](r)びます。</span>
+- <span lang="ja">^公,こう,園,えん^に^行,い^==って==^遊,あそ^びます。</span>
 - I went to the park and (then) played.
 
 More than one verb may be chained up this way.
 
-## Using [前,まえ](r) (before)
+## Using ^前,まえ^ (before)
 
-The plain form of a very may be appended with <span lang=ja>[前,まえ](r)に</span>
+The plain form of a very may be appended with <span lang=ja>^前,まえ^に</span>
 to make it come after the action which follows.
 
-- <span lang="ja">[寝,ね](r)る==前に==、[歯,は](r)を[磨,みが](r)きます。
+- <span lang="ja">^寝,ね^る==前に==、^歯,は^を^磨,みが^きます。
   </span>
 - Literal: ==Before== going to bed, I brushed my teeth.
 - Natural: I brushed my teeth ==before== going to bed.
@@ -34,31 +34,31 @@ to make it come after the action which follows.
 The <span lang="ja">て</span> form may be appended with
 <span lang="ja">から</span> to indicate that it comes before the next verb.
 
-- <span lang="ja">[歯,は](r)を[磨,みが](r)い==てから==、[寝,ね](r)ます。
+- <span lang="ja">^歯,は^を^磨,みが^い==てから==、^寝,ね^ます。
   </span>
 - Literal: ==After== brushing my teeth, I went to bed.
 - Natural: I went to bed ==after== brushing my teeth.
 
-## Using [後,あと](r) (after)
+## Using ^後,あと^ (after)
 
 The <span lang="ja">た</span> form of a verb may be appended with
-<span lang="ja">[後,あと](r)で</span> to indicade that it comes before the
+<span lang="ja">^後,あと^で</span> to indicade that it comes before the
 next verb.
 
-- <span lang="ja">[歯,は](r)を[磨,みが](r)い==た後で==、[寝,ね](r)ます。
+- <span lang="ja">^歯,は^を^磨,みが^い==た後で==、^寝,ね^ます。
   </span>
 - Literal: ==After== brushing my teeth, I went to bed.
 - Natural: I went to bed ==after== brushing my teeth.
 
-## Using [時,とき](r) (before and after)</span>
+## Using ^時,とき^ (before and after)</span>
 
-[時,とき](r) can be used for both before and after, depending on the tense of
+^時,とき^ can be used for both before and after, depending on the tense of
 the verb it is appended to.
 
 When the verb is in the plain form, it happens _after_ the next verb. Note that
 the tense of the whole sentence is carried by the latter verb.
 
-- <span lang="ja">[寝,ね](r)る==時==、[歯,は](r)を[磨,みが](r)きました。
+- <span lang="ja">^寝,ね^る==時==、^歯,は^を^磨,みが^きました。
   </span>
 - Literal: When I went to bed, I brushed my teeth.
 - Natural: I brushed my teeth before I went to bed.
@@ -66,6 +66,6 @@ the tense of the whole sentence is carried by the latter verb.
 When the verb is in the past form, it happens before the next verb. Again, the
 tense of the whole sentence is carried by the latter verb.
 
-- <span lang="ja">[起,お](r)き==た時==、シャワーを[浴,あ](r)びます。</span>
+- <span lang="ja">^起,お^き==た時==、シャワーを^浴,あ^びます。</span>
 - Literal: After waking up I take take a shower.
 - Natural: I take a shower after waking up.

--- a/content/japanese-notes/conditionals-and-hypotheticals-using-tara.md
+++ b/content/japanese-notes/conditionals-and-hypotheticals-using-tara.md
@@ -22,13 +22,13 @@ this yet. It usually seems right to omit it.
 
 Noun example:
 
-- <span lang="ja">[僕,ぼく](r)だったら、[新,あたら](r)しいアパートを[探,さが](r)す。</span>
+- <span lang="ja">^僕,ぼく^だったら、^新,あたら^しいアパートを^探,さが^す。</span>
 - Literal: If it were me, I'd look for a new apartment.
 - Natural: I would look for a new apartment.
 
 Verb example:
 
-- <span lang="ja">このキノコを[食,た](r)べたら、[背,せ](r)が[高,たか](r)くなります。</span>
+- <span lang="ja">このキノコを^食,た^べたら、^背,せ^が^高,たか^くなります。</span>
 - Literal: If you eat this mushroom, you will become taller.
 - Natural: Eating this mushroom will make you taller.
 

--- a/content/japanese-notes/i-am-going-to.md
+++ b/content/japanese-notes/i-am-going-to.md
@@ -5,11 +5,11 @@
   "description": "The volitional form can be used to express a determination or decision to do something."
 }
 ---
-A combination of the [volitional](volitional-form) form of a verb and <span lang="ja">〜と[思,おも](r)います</span>.
+A combination of the [volitional](volitional-form) form of a verb and <span lang="ja">〜と^思,おも^います</span>.
 
 For example:
 
-- <span lang="ja">[今日,きょう](r)、[公,こう,園,えん](r)に[行,い](r)こうと[思,おも](r)います。</span>
+- <span lang="ja">^今日,きょう^、^公,こう,園,えん^に^行,い^こうと^思,おも^います。</span>
 - Literal: I think I shall go to the park today.
 - Natural: I (have just decided I) will go to the park today.
 
@@ -19,6 +19,6 @@ decision.
 The sentence can be modified to the present progressive to indicate that the
 decision is not new.
 
-- <span lang="ja">[今日,きょう](r)、[公,こう,園,えん](r)に[行,い](r)こうと[思,おも](r)っています。</span>
+- <span lang="ja">^今日,きょう^、^公,こう,園,えん^に^行,い^こうと^思,おも^っています。</span>
 - Literal: I am thinking that I shall go to the park today.
 - Natural: I (decided earlier that I) will go to the park today.

--- a/content/japanese-notes/introduction.md
+++ b/content/japanese-notes/introduction.md
@@ -8,13 +8,11 @@
 It's about time I started keeping notes again! I've engineered in just enough
 to make it fun rather than an hindrance. For example, I can how write furigana
 in a way that doesn't look out of place in markdown. For example,
-`[私,わたし](r)` renders as [私,わたし](r). It also works on
+`^私,わたし^` renders as ^私,わたし^. It also works on
 words with multiple ruby components. For example
-`[振,ふ,り,,仮名,がな](r)` renders as [振,ふ,り,,仮名,がな](r).
+`^振,ふ,り,,仮名,がな^` renders as ^振,ふ,り,,仮名,がな^.
 The comma separated list is paired groups of characters (which is why the
-<span lang="ja">り</span> is followed by an empty element). I'm abusing markdown
-links to do this, but since `r` is not a valid URL it's an acceptable tradeoff
-in my opinion.
+<span lang="ja">り</span> is followed by an empty element).
 
 At this time I use spans with a language attribute to wrap segments of Japanese
 text. No special markdown syntax. This allows me to apply a font stack using

--- a/content/japanese-notes/mada-not-yet-still.md
+++ b/content/japanese-notes/mada-not-yet-still.md
@@ -11,13 +11,13 @@
 For affirmative forms of verbs <span lang="ja">まだ</span> means _still_.
 Example:
 
-- <span lang="ja">==まだ==[日,に,本,ほん,語,ご](r)を[勉,べん,強,きょう](r)してるの？</span>
+- <span lang="ja">==まだ==^日,に,本,ほん,語,ご^を^勉,べん,強,きょう^してるの？</span>
 - Are you ==still== studying Japanese?
 
 For negative forms of verbs <span lang="ja">まだ</span> means _not yet_. That
 said, it still means _still_ when you think about it!
 
-- <span lang="ja">まだエディンバラに[行,い](r)きません。</span>
+- <span lang="ja">まだエディンバラに^行,い^きません。</span>
 - I haven't been to Edinburgh yet.
 - I still haven't been to Edinburgh.
 

--- a/content/japanese-notes/mo-dake-and-shika.md
+++ b/content/japanese-notes/mo-dake-and-shika.md
@@ -17,7 +17,7 @@ nuance that the speaker feels that the quantity is large.
 Example:
 
 - Mark has _ten_ cars.
-- <span lang="ja">マークさんは[車,くるま](r)を十台==も==[持,も](r)っています。</span>
+- <span lang="ja">マークさんは^車,くるま^を十台==も==^持,も^っています。</span>
 
 ## Not many using <span lang="ja">だけ</span>
 
@@ -28,7 +28,7 @@ the speaker feels the quantity is low.
 Example:
 
 - Mark _only_ has one pen.
-- <span lang="ja">マークさんはペンを一つ==だけ==[持,も](r)っています。</span>
+- <span lang="ja">マークさんはペンを一つ==だけ==^持,も^っています。</span>
 
 ## Not many using <span lang="ja">しか</span>
 
@@ -40,7 +40,7 @@ that the verb used is in its negative form.
 Example:
 
 - Mark _only_ has one pen.
-- <span lang="ja">マークさんはペンを一つ==しか==[持,も](r)って==いません==。</span>
+- <span lang="ja">マークさんはペンを一つ==しか==^持,も^って==いません==。</span>
 
 I'd entirely forgotten how to use <span lang="ja">しか</span> since early on I'd
 learnt about <span lang="ja">だけ</span>, which doesn't negate the verb (making

--- a/content/japanese-notes/mou-already-anymore.md
+++ b/content/japanese-notes/mou-already-anymore.md
@@ -11,12 +11,12 @@ case, or will not be the case again.
 
 Consider this famous line from Fist of the North Star:
 
-- <span lang="ja">お[前,まえ](r)は==もう==[死,し](r)んでいる。</span>
+- <span lang="ja">お^前,まえ^は==もう==^死,し^んでいる。</span>
 - You are ==already== dead.
 
 When used with negative form verbs, <span lang="ja">もう</span> means _anymore_. Example:
 
-- <span lang="ja">==もう==[行,い](r)かない</span>
+- <span lang="ja">==もう==^行,い^かない</span>
 - I won't go ==anymore==.
 
 <span lang="ja">もう</span> is often contrasted with <span lang="ja">まだ</span>.

--- a/content/japanese-notes/potential-form.md
+++ b/content/japanese-notes/potential-form.md
@@ -6,46 +6,46 @@
   "description": "Hub for the potential form of verbs."
 }
 ---
-This page is a hub for the potential form, or [可,か,能,のう,形,けい](r). It
+This page is a hub for the potential form, or ^可,か,能,のう,形,けい^. It
 describes how to conjugate verbs to their potential form, and links out to other
 articles about its use. See backlinks at the bottom for notes linking to this
 one.
 
-### [一,いち,段,だん](r) verbs
+### ^一,いち,段,だん^ verbs
 
 Remove the trailing <span lang="ja">る</span> and replace it with
 <span lang="ja">られる</span>. In a casual context the <span lang="ja">ら</span>
 in the <span lang="ja">られる</span> can be dropped so the appended part becomes
 <span lang="ja">れる</span>.
 
-- <span lang="ja">[食,た](r)べ==る==</span>: to eat
-- <span lang="ja">[食,た](r)べ==られる==</span>: can eat
+- <span lang="ja">^食,た^べ==る==</span>: to eat
+- <span lang="ja">^食,た^べ==られる==</span>: can eat
 
-### [五,ご,段,だん](r) verbs
+### ^五,ご,段,だん^ verbs
 
 Replace the last kana in the dictionary form of the verb with it's -e sound
 companion in the same row of the kana table and append <span lang="ja">る</span>
 after.
 
-- <span lang="ja">[遊,あそ](r)==ぶ==</span>: to play
-- <span lang="ja">[遊,あそ](r)==べる==</span>: can play
+- <span lang="ja">^遊,あそ^==ぶ==</span>: to play
+- <span lang="ja">^遊,あそ^==べる==</span>: can play
 
 ### <span lang="ja">する</span>
 
 - <span lang="ja">==する==</span>: to do
-- <span lang="ja">==[出,で,来,き](r)る==: can do
+- <span lang="ja">==^出,で,来,き^==: can do
 
-### <span lang="ja">[来,く](r)る</span>
+### <span lang="ja">^来,く^る</span>
 
-- <span lang="ja">[来,く](r)==る==</span>: to come
-- <span lang="ja">[来,こ](r)==られる==</span>: can come
+- <span lang="ja">^来,く^==る==</span>: to come
+- <span lang="ja">^来,こ^==られる==</span>: can come
 
 ### <span lang="ja">ある</span>
 
 <span lang="ja">ある</span> is irregular for this conjugation and becomes:
 
 - <span lang="ja">ある</span>: to be (inanimate)
-- <span lang="ja">あり[得,え](r)る</span>: can be (is possible)
+- <span lang="ja">あり^得,え^る</span>: can be (is possible)
 
-Where <span lang="ja">[得,え](r)る</span> means _to gain_, which is
+Where <span lang="ja">^得,え^る</span> means _to gain_, which is
 interesting!

--- a/content/japanese-notes/te-form.md
+++ b/content/japanese-notes/te-form.md
@@ -6,20 +6,20 @@
   "description": "Hub for the te form of verbs."
 }
 ---
-This page is a hub for the te form, or <span lang="ja">て[形,けい](r)</span>. It
+This page is a hub for the te form, or <span lang="ja">て^形,けい^</span>. It
 describes how to conjugate verbs to their te form, and links out to other
 articles about its use. See backlinks at the bottom for notes linking to this
 one.
 
-### [一,いち,段,だん](r) verbs
+### ^一,いち,段,だん^ verbs
 
 Remove the trailing <span lang="ja">る</span> and replace it with a
 <span lang="ja">て</span>.
 
-- <span lang="ja">[食,た](r)べ==る==</span>: to eat
-- <span lang="ja">[食,た](r)べ==て==</span>
+- <span lang="ja">^食,た^べ==る==</span>: to eat
+- <span lang="ja">^食,た^べ==て==</span>
 
-### [五,ご,段,だん](r) verbs
+### ^五,ご,段,だん^ verbs
 
 The conjugation depends on the final kana in the verb:
 
@@ -33,26 +33,26 @@ When the verb ends in <span lang="ja">う</span>, <span lang="ja">つ</span>, or
 When the verb ends with <span lang="ja">す</span> replace the trailing kana with
 <span lang="ja">して</span>.
 
-- <span lang="ja">[話,はな](r)==す==</span>: to speak
-- <span lang="ja">[話,はな](r)==して==</span>
+- <span lang="ja">^話,はな^==す==</span>: to speak
+- <span lang="ja">^話,はな^==して==</span>
 
 When the verb ends with <span lang="ja">く</span> replace the trailing kana with
 <span lang="ja">いて</span>.
 
-- <span lang="ja">[履,は](r)==く==</span>: to put on (lower body)
-- <span lang="ja">[履,は](r)==いて==</span>
+- <span lang="ja">^履,は^==く==</span>: to put on (lower body)
+- <span lang="ja">^履,は^==いて==</span>
 
 Similarly, when a verb ends in a voiced kana, the te form is also voiced:
 
-- <span lang="ja">[急,いそ](r)==ぐ==</span>: to hurry
-- <span lang="ja">[急,いそ](r)==いで==</span>
+- <span lang="ja">^急,いそ^==ぐ==</span>: to hurry
+- <span lang="ja">^急,いそ^==いで==</span>
 
 Finally, when the verb ends in <span lang="ja">ぬ</span>,
 <span lang="ja">ぶ</span>, or <span lang="ja">む</span>, replace the trailing
 kana with <span lang="ja">んで</span>.
 
-- <span lang="ja">[住,す](r)==む==</span>: to inhabit
-- <span lang="ja">[住,す](r)==んで==</span>
+- <span lang="ja">^住,す^==む==</span>: to inhabit
+- <span lang="ja">^住,す^==んで==</span>
 
 ### Irregular conjugations
 
@@ -60,12 +60,12 @@ kana with <span lang="ja">んで</span>.
 - <span lang="ja">==して==</span>
 
 
-- <span lang="ja">[来,く](r)==る==</span>: to come
-- <span lang="ja">[来,き](r)==て==</span>
+- <span lang="ja">^来,く^==る==</span>: to come
+- <span lang="ja">^来,き^==て==</span>
 
 
-- <span lang="ja">[行,い](r)==く==</span>: to go
-- <span lang="ja">[行,い](r)==って==</span>
+- <span lang="ja">^行,い^==く==</span>: to go
+- <span lang="ja">^行,い^==って==</span>
 
 
 - <span lang="ja">〜ま==す==</span>

--- a/content/japanese-notes/te-form.md
+++ b/content/japanese-notes/te-form.md
@@ -56,17 +56,7 @@ kana with <span lang="ja">んで</span>.
 
 ### Irregular conjugations
 
-- <span lang="ja">==する==</span>: to do
-- <span lang="ja">==して==</span>
-
-
-- <span lang="ja">^来,く^==る==</span>: to come
-- <span lang="ja">^来,き^==て==</span>
-
-
-- <span lang="ja">^行,い^==く==</span>: to go
-- <span lang="ja">^行,い^==って==</span>
-
-
-- <span lang="ja">〜ま==す==</span>
-- <span lang="ja">〜ま==して==</span>
+- <span lang="ja">==する==</span> (to do): <span lang="ja">==して==</span>
+- <span lang="ja">^来,く^==る==</span> (to come): <span lang="ja">^来,き^==て==</span>
+- <span lang="ja">^行,い^==く==</span> (to go): <span lang="ja">^行,い^==って==</span>
+- <span lang="ja">〜ま==す==</span>: <span lang="ja">〜ま==して==</span>

--- a/content/japanese-notes/verb-conjugations.md
+++ b/content/japanese-notes/verb-conjugations.md
@@ -12,17 +12,17 @@ specific conjugations.
 
 In the linked notes, I use the terminology:
 
-- <span lang="ja">[五,ご,段,だん](r)</span> verbs, also known as
+- <span lang="ja">^五,ご,段,だん^</span> verbs, also known as
   <span lang="ja">う</span>-verbs, group 1 verbs, and consonant-stem verbs.
-- <span lang="ja">[一,いち,段,だん](r)</span> verbs, also known as
+- <span lang="ja">^一,いち,段,だん^</span> verbs, also known as
   <span lang="ja">る</span>-verbs, group 2 verbs, and vowel-stem verbs.
 - Irregular verbs. These very depending on the conjugation, but the two most
   commonly seen are <span lang="ja">する</span> and
-  <span lang="ja">[来,く](r)る</span>. However, there are others!
+  <span lang="ja">^来,く^る</span>. However, there are others!
 
 Conjugations of verbs documented here:
 
 - The dictionary form (verbs are catalogued in this form).
-- The [te form](te-form), <span lang="ja">て[形,けい](r)</span>.
-- The [potential form](potential-form), [可,か,能,のう,形,けい](r).
-- The [volitional form](volitional-form), [意,い,向,こう,形,けい](r).
+- The [te form](te-form), <span lang="ja">て^形,けい^</span>.
+- The [potential form](potential-form), ^可,か,能,のう,形,けい^.
+- The [volitional form](volitional-form), ^意,い,向,こう,形,けい^.

--- a/content/japanese-notes/want-another-to-do-with-te-hoshii.md
+++ b/content/japanese-notes/want-another-to-do-with-te-hoshii.md
@@ -10,7 +10,7 @@ When you want to express a desire for another to perform some action, use the
 <span lang="ja">て</span> form of a verb and append
 <span lang="ja">ほしい</span> to it.
 
-- [息,むす,子,こ](r)にもっと[野,や,菜,さい](r)を==[食,た](r)べてほしい==です。
+- ^息,むす,子,こ^にもっと^野,や,菜,さい^を==^食,た^べてほしい==です。
 - (I) ==want== my son ==to eat== more vegetables.
 
 When mentioning the person the desire is directed toward explicitly, use the

--- a/lib/render.js
+++ b/lib/render.js
@@ -41,16 +41,12 @@ function renderMaths(code, id) {
   return svg.outerHTML;
 }
 
-function escapeForTextNode(string) {
-  return string.replace(/[&<>]/g, c => `&${{ '&': 'amp', '<': 'lt', '>': 'gt' }[c]};`);
-}
-
 function buildRuby(elements) {
   const content = [];
 
   for (let i = 0; i < elements.length; i += 2) {
-    const base = escapeForTextNode(elements[i]);
-    const text = escapeForTextNode(elements[i + 1]);
+    const base = elements[i];
+    const text = elements[i + 1];
 
     content.push(base, text ? `<rp>(</rp><rt>${text}</rt><rp>)</rp>` : '<rt></rt>');
   }
@@ -99,33 +95,6 @@ marked.use({
   highlight(code, language) {
     return highlightjs.highlight(code, { language }).value;
   },
-  walkTokens(token) {
-    if (token.type === 'paragraph' && token.raw.startsWith('$$\n') && token.raw.endsWith('\n$$')) {
-      token.type = 'code';
-      token.lang = 'mathematics';
-      token.tokens.length = 0;
-      token.text = token.raw.slice(3, -3);
-    }
-
-    if (token.type === 'link' && !token.inLink && !token.inRawBlock && token.href === 'r') {
-      token.type = 'html';
-      token.text = buildRuby(token.text.split(','));
-
-      delete token.href;
-      delete token.inLink;
-      delete token.inRawBlock;
-    }
-  },
-  renderer: {
-    code(code, language) {
-      if (language === 'mathematics') {
-        this.options.equation++;
-        return renderMaths(code, `equation-${this.options.equation}`);
-      }
-
-      return false;
-    }
-  },
   extensions: [
     {
       name: 'mark',
@@ -150,6 +119,60 @@ marked.use({
       },
       renderer(token) {
         return `<mark>${this.parser.parseInline(token.inner)}</mark>`;
+      }
+    },
+    {
+      name: 'maths-block',
+      level: 'block',
+      start(src) {
+        return src.match(/^\$\$$/)?.index;
+      },
+      tokenizer(src) {
+        if (!src.startsWith('$$\n')) {
+          return;
+        }
+
+        const nextIndex = src.indexOf('\n$$');
+
+        if (nextIndex !== -1) {
+          return {
+            type: 'maths-block',
+            raw: src.slice(0, nextIndex + 3),
+            inner: src.slice(3, nextIndex)
+          };
+        }
+      },
+      renderer(token) {
+        this.parser.options.equation++;
+        return renderMaths(token.inner, `equation-${this.parser.options.equation}`);
+      }
+    },
+    {
+      name: 'ruby',
+      level: 'inline',
+      start(src) {
+        return src.match(/\^/)?.index;
+      },
+      tokenizer(src) {
+        if (!src.startsWith('^')) {
+          return;
+        }
+
+        const nextIndex = src.indexOf('^', 1);
+
+        if (nextIndex !== -1) {
+          return {
+            type: 'ruby',
+            raw: src.slice(0, nextIndex + 1),
+            inner: src
+              .slice(1, nextIndex)
+              .split(',')
+              .map(el => this.lexer.inlineTokens(el))
+          };
+        }
+      },
+      renderer(tokens) {
+        return buildRuby(tokens.inner.map(el => this.parser.parseInline(el)));
       }
     }
   ]

--- a/tests/units/render.test.js
+++ b/tests/units/render.test.js
@@ -70,7 +70,7 @@ describe('render', () => {
 
   describe('inline ruby links', () => {
     it('renders ruby elements', () => {
-      const rendered = render('[買,か,いに,,行,い,く,](r)', URL).trim();
+      const rendered = render('^買,か,いに,,行,い,く,^', URL).trim();
       const { window: { document } } = new JSDOM(rendered);
       const $rubies = document.getElementsByTagName('ruby');
 


### PR DESCRIPTION
## New syntax for rubies

This:

```markdown
[私,わたし](r)
```

is replaced with

```markdown
^私,わたし^
```

i.e. not more abusing markdown links to get what I want.

## Formalizing maths blocks

There are no syntax changes for maths blocks, but the way they're handled internally is no longer a hack. It works using the new marked extensions feature.