### PR TITLE
Multiple image formats for notes

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,10 +145,11 @@ export async function build({ baseUrl, baseTitle, dev, syndications }) {
       dependencies: ['paths', 'images'],
       async action({ paths: { content }, images: imagesDimensions }) {
         const notesPath = new URL('notes/', content);
+        const imagesPath = new URL('images/', content);
 
         return ExecutionGraph.createWatchableResult({
           path: notesPath,
-          result: await loadNoteFiles(notesPath, syndications, imagesDimensions)
+          result: await loadNoteFiles(notesPath, imagesPath, syndications, imagesDimensions)
         });
       }
     },

--- a/lib/load-note-files.js
+++ b/lib/load-note-files.js
@@ -1,11 +1,21 @@
-import { readdir, readFile } from 'node:fs/promises';
+import { constants } from 'fs';
+import { readdir, readFile, access } from 'node:fs/promises';
 import handlebars from 'handlebars';
 import getTimezone from './get-timezone.js';
 
 const makeSnippet = handlebars.compile('<p class="p-summary">{{content}}</p>');
 const makeFeedItem = handlebars.compile('<p>{{content}}</p>');
 
-export default async function loadNoteFiles(dir, syndications, imagesDimensions) {
+async function fileReadable(url) {
+  try {
+    await access(url, constants.R_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export default async function loadNoteFiles(dir, imagesDir, syndications, imagesDimensions) {
   const filenames = await readdir(dir);
   const notes = await Promise.all(filenames.filter(fn => fn.endsWith('.json')).map(async (filename, index) => {
     const note = JSON.parse(await readFile(new URL(filename, dir), 'utf8'));
@@ -14,13 +24,27 @@ export default async function loadNoteFiles(dir, syndications, imagesDimensions)
     const filteredSyndications = [].concat(rawSyndications).filter(Boolean);
 
     const [content] = note.properties.content;
-    const photos = (photo || []).map(p => typeof p === 'string' ? { value: p, alt: content } : p);
+    const photos = await Promise.all((photo || []).map(async p => {
+      const photo = typeof p === 'string' ? { value: p, alt: content } : { ...p };
+      const name = photo.value.match(/\/(?<name>\d+)\./)?.groups.name;
 
-    for (const photo of photos) {
-      const { width, height } = imagesDimensions.get(photo.value);
-      photo.width = width;
-      photo.height = height;
-    }
+      await Promise.all([
+        fileReadable(new URL(`${name}.avif`, imagesDir)).then(exists => {
+          if (exists) {
+            photo.avif = `/images/${name}.avif`;
+          }
+        }),
+        fileReadable(new URL(`${name}.webp`, imagesDir)).then(exists => {
+          if (exists) {
+            photo.webp = `/images/${name}.webp`;
+          }
+        })
+      ]);
+
+      Object.assign(photo, imagesDimensions.get(photo.value));
+
+      return photo;
+    }));
 
     return {
       hType,

--- a/scripts/serve.js
+++ b/scripts/serve.js
@@ -77,7 +77,18 @@ const syndications = {
   });
 
   // Host files from the public directory.
-  app.use(serveStatic('public', { extensions: ['html'] }));
+  app.use(serveStatic('public', {
+    extensions: ['html'],
+    setHeaders(res, path) {
+      // The database behind serve-static doesn't understand these endings yet,
+      // so handle them manually.
+      if (path.endsWith('avif')) {
+        res.setHeader('Content-Type', 'image/avif');
+      } else if (path.endsWith('webp')) {
+        res.setHeader('Content-Type', 'image/webp');
+      }
+    }
+  }));
 
   // This middleware handles everything not handled before it (404).
   app.use((_req, res) => {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -232,7 +232,6 @@ input {
 }
 
 .profile-pic {
-  border: 1px solid var(--standout-color-main);
   margin: 0 0 1rem 1rem;
   width: 150px;
   height: auto;
@@ -273,6 +272,7 @@ img {
   width: 100%;
   height: auto;
   border: 1px solid var(--standout-color-main);
+  box-sizing: border-box;
 }
 
 .ruby-position-off rt,

--- a/src/templates/partials/note.html.handlebars
+++ b/src/templates/partials/note.html.handlebars
@@ -9,6 +9,10 @@
     {{#if syndications.mastodon}}<a class="mention-of" href="https://brid.gy/publish/mastodon"></a>{{/if}}
   </p>
   {{#photos}}
-    <img class="u-photo" src="{{value}}" alt="{{alt}}" width="{{width}}" height="{{height}}" loading="lazy">
+    <picture>
+      {{#avif}}<source type="image/avif" srcset="{{@this}}">{{/avif}}
+      {{#webp}}<source type="image/webp" srcset="{{@this}}">{{/webp}}
+      <img class="u-photo" src="{{value}}" alt="{{alt}}" width="{{width}}" height="{{height}}" loading="lazy">
+    </picture>
   {{/photos}}
 </article>


### PR DESCRIPTION
Once this is merged, notes will be served with multiple image sources. This will allow (at the time of writing) chrome-like and firefox browsers to use AVIF, and safari browsers to use WebP when images in those formats are available. I'll follow this PR up with one to add alternative images in those formats for existing images.