### PR TITLE
Replace date tags used for durations with time tags.

### DIFF
--- a/src/templates/partials/study-session.html.handlebars
+++ b/src/templates/partials/study-session.html.handlebars
@@ -1,7 +1,7 @@
 <article class={{hType}} light-emoji="{{lightEmoji}}" dark-emoji="{{darkEmoji}}">
   {{> hcard-basics additionalClasses="p-author" }}
   <header>
-    <a class="u-url" href="/study-sessions/{{timestamp}}"><time datetime="{{datetime}}" class="dt-end">{{humanDateTime datetime timezone}}</time> for <data class="dt-duration" value={{isoDuration}}>{{duration}}</data>.</a>
+    <a class="u-url" href="/study-sessions/{{timestamp}}"><time datetime="{{datetime}}" class="dt-end">{{humanDateTime datetime timezone}}</time> for <time class="dt-duration" datetime={{isoDuration}}>{{duration}}</time>.</a>
   </header>
   <p class="e-content p-name">
     {{content}}: {{#categories}} <span class="p-category">{{@this}}</span>{{/categories}}


### PR DESCRIPTION
It's surprising to me that <time> is intended to be used for dates, times, *and* durations, but that's what the spec says!