### PR TITLE
Fixes build plugins.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,8 +2,5 @@
   "extends": "qubyte/ES2022-module",
   "env": {
     "node": true
-  },
-  "globals": {
-    "fetch": true
   }
 }

--- a/functions/function-helpers/check-auth.js
+++ b/functions/function-helpers/check-auth.js
@@ -1,3 +1,5 @@
+import { fetch } from 'undici';
+
 export async function checkAuth(headers) {
   if (headers['short-circuit-auth']) {
     if (headers.authorization !== `Bearer ${process.env.SHORT_CIRCUIT_AUTH}`) {

--- a/functions/function-helpers/upload.js
+++ b/functions/function-helpers/upload.js
@@ -1,3 +1,5 @@
+import { fetch } from 'undici';
+
 export async function upload(message, type, filename, buffer) {
   const body = JSON.stringify({ message, content: buffer.toString('base64') });
   const path = `content/${type}/${filename}`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,8 @@
         "postcss-import": "^14.1.0",
         "sharp": "0.30.4",
         "slugify": "1.6.5",
-        "twitter-lite": "^1.1.0"
+        "twitter-lite": "^1.1.0",
+        "undici": "5.0.0"
       },
       "devDependencies": {
         "@toisu/static": "4.0.3",
@@ -4278,6 +4279,14 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/undici": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.0.0.tgz",
+      "integrity": "sha512-VhUpiZ3No1DOPPQVQnsDZyfcbTTcHdcgWej1PdFnSvOeJmOVDgiOHkunJmBLfmjt4CqgPQddPVjSWW0dsTs5Yg==",
+      "engines": {
+        "node": ">=12.18"
+      }
+    },
     "node_modules/universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -7635,6 +7644,11 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.5.tgz",
       "integrity": "sha512-qZukoSxOG0urUTvjc2ERMTcAy+BiFh3weWAkeurLwjrCba73poHmG3E36XEjd/JGukMzwTL7uCxZiAexj8ppvQ==",
       "optional": true
+    },
+    "undici": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.0.0.tgz",
+      "integrity": "sha512-VhUpiZ3No1DOPPQVQnsDZyfcbTTcHdcgWej1PdFnSvOeJmOVDgiOHkunJmBLfmjt4CqgPQddPVjSWW0dsTs5Yg=="
     },
     "universalify": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "postcss-import": "^14.1.0",
     "sharp": "0.30.4",
     "slugify": "1.6.5",
-    "twitter-lite": "^1.1.0"
+    "twitter-lite": "^1.1.0",
+    "undici": "5.0.0"
   },
   "devDependencies": {
     "@toisu/static": "4.0.3",

--- a/plugins/dispatch-webmentions/dispatch-webmentions-for-url.js
+++ b/plugins/dispatch-webmentions/dispatch-webmentions-for-url.js
@@ -1,5 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import { pathToFileURL } from 'node:url';
+import { fetch } from 'undici';
 import linkHeader from 'http-link-header';
 import { JSDOM } from 'jsdom';
 

--- a/plugins/fetch-old-feed-to-urls.js
+++ b/plugins/fetch-old-feed-to-urls.js
@@ -1,4 +1,5 @@
 import { Readable } from 'node:stream';
+import { fetch } from 'undici';
 import retry from 'p-retry';
 import parseFeedToUrls from './parse-feed-to-urls.js';
 

--- a/plugins/tweet-new-blog-posts/get-tags-for-url.js
+++ b/plugins/tweet-new-blog-posts/get-tags-for-url.js
@@ -1,3 +1,4 @@
+import { fetch } from 'undici';
 import { JSDOM } from 'jsdom';
 
 export default async function getTagsForUrl(url) {

--- a/scripts/publish-scheduled.js
+++ b/scripts/publish-scheduled.js
@@ -3,6 +3,7 @@
 import fs from 'node:fs/promises';
 import { parseFrontMatter } from '../lib/load-post-files.js';
 import retry from 'p-retry';
+import { fetch } from 'undici';
 
 const LAST_BUILD_URL = 'https://qubyte.codes/last-build.txt';
 const POST_FILES_DIR = new URL('../content/posts/', import.meta.url);


### PR DESCRIPTION
Plugins on netlify appear to run in Node 16, with no way to configure it, which means global fetch isn't available there. This PR requires in undici to bridge the gap.