### PR TITLE
Adds a minimal webmention receiver.

### DIFF
--- a/functions/receive-webmention.js
+++ b/functions/receive-webmention.js
@@ -1,0 +1,61 @@
+import fetch from 'node-fetch';
+
+// Some blogs dispatch *all* mentions on every build or something. Whenever that
+// happens add the offending source URL to the list.
+const IGNORED_SOURCES = [
+  'https://www.jvt.me/mf2/2019/06/pmsth/'
+];
+
+export async function handler(event) {
+  console.log('GOT REQUEST', { body: event.body });
+
+  const body = new URLSearchParams(event.body);
+
+  if (!body.has('source') || !body.has('target')) {
+    return { statusCode: 400, body: 'Bad body format.' };
+  }
+
+  let source;
+  let target;
+
+  try {
+    source = new URL(body.get('source'));
+    target = new URL(body.get('target'));
+  } catch (e) {
+    return { statusCode: 400, body: 'Source and target must be valid, fully qualified URLs.' };
+  }
+
+  if (!target.href.startsWith(process.env.URL)) {
+    return { statusCode: 400, body: 'Target URLs must be for this domain.' };
+  }
+
+  if (IGNORED_SOURCES.includes(source)) {
+    return { statusCode: 429, body: 'Please don\'t send mentions more than once if they don\'t change.' };
+  }
+
+  // This is an MVP. At the moment it will only send a source and a target to
+  // GitHub in a link. Manual steps afterward:
+  //
+  // - Check the source actually links to the target.
+  // - Get author details from the source.
+  // - Determine the kind of mention (note, like, repost, etc.)
+
+  const res = await fetch('https://api.github.com/repos/qubyte/qubyte-codes/issues', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Basic ${Buffer.from(`qubyte:${process.env.GITHUB_TOKEN}`).toString('base64')}`
+    },
+    body: JSON.stringify({
+      title: `New webmention from ${source.hostname}!`,
+      body: `source: [${source}](${source})\ntarget: [${target}](${target})\n`,
+      labels: ['webmention']
+    })
+  });
+
+  if (!res.ok) {
+    return { statusCode: 502, body: `Unexpected response status from GitHub: ${res.status}` };
+  }
+
+  return { statusCode: 202 };
+}

--- a/src/templates/partials/head.html.handlebars
+++ b/src/templates/partials/head.html.handlebars
@@ -23,9 +23,8 @@
 <link rel="authorization_endpoint" href="https://indieauth.com/auth">
 <link rel="token_endpoint" href="https://tokens.indieauth.com/token">
 <link rel="micropub" href="{{baseUrl}}/.netlify/functions/micropub">
+<link rel="webmention" href="{{baseUrl}}/.netlify/functions/receive-webmention">
 <link rel="vcs-git" href="/qubyte-codes.git">
-<link href="https://webmention.io/qubyte.codes/xmlrpc" rel="pingback">
-<link href="https://webmention.io/qubyte.codes/webmention" rel="webmention">
 {{#if localUrl}}
 <link href={{baseUrl}}{{localUrl}} rel="canonical">
 {{/if}}


### PR DESCRIPTION
The current receiver is webmention.io, which sends a webhook requesst to a glitch, which creates a GitHub issue. While webmention.io is much more featureful, I want to handle webmentions on my own domain. This PR adds a Netlify function to act as a minimal webmention receiver, and create GitHub issues directly.