### PR TITLE
Uses sharp to perform image copying.

### DIFF
--- a/index.js
+++ b/index.js
@@ -368,10 +368,10 @@ export async function build({ baseUrl, baseTitle, dev, syndications }) {
 
         return new Map(await Promise.all(
           items.map(async item => {
-            const sourceFile = await readFile(new URL(item, directory));
-            const { width, height } = await sharp(sourceFile).metadata();
+            const image = sharp(new URL(item, directory));
+            const { width, height } = await image.metadata();
 
-            await writeFile(new URL(item, imagesTarget), sourceFile);
+            await image.toFile(new URL(item, imagesTarget));
 
             return [`/images/${item}`, { width, height }];
           })

--- a/index.js
+++ b/index.js
@@ -368,10 +368,10 @@ export async function build({ baseUrl, baseTitle, dev, syndications }) {
 
         return new Map(await Promise.all(
           items.map(async item => {
-            const image = sharp(new URL(item, directory));
+            const image = sharp(fileURLToPath(new URL(item, directory)));
             const { width, height } = await image.metadata();
 
-            await image.toFile(new URL(item, imagesTarget));
+            await image.toFile(fileURLToPath(new URL(item, imagesTarget)));
 
             return [`/images/${item}`, { width, height }];
           })


### PR DESCRIPTION
This change does two things which are useful:

- Removes metadata from copied images.
- Streams rather than buffers, which should lower the memory overhead.