### PR TITLE
Turn off image post-processing.

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,7 @@
   pretty_urls = true
 
 [build.processing.images]
-  compress = true
+  compress = false
 
 [build.processing.css]
   bundle = false


### PR DESCRIPTION
These are processed before they're committed to the repo, and it probably adds a big chunk of time per deployment so it may be an easy win to turn off image compression.