### PR TITLE
Adds an import map with aggressive caching as a progressive enhancement.

### DIFF
--- a/lib/hash-copy.js
+++ b/lib/hash-copy.js
@@ -1,0 +1,50 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { parse as esParse } from 'espree';
+import { traverse } from 'estraverse';
+
+function findImports(scriptSource) {
+  const dependencies = [];
+  const tree = esParse(scriptSource, { ecmaVersion: 2022, sourceType: 'module' });
+
+  traverse(tree, {
+    enter({ type, source }) {
+      // The target of an import expression can't always be known statically,
+      // but when it is a plain string we can use it. It may be worth adding or
+      // using an ESLint rule to enforce `import()` only receives plain strings.
+      if (type === 'ImportDeclaration' || (type === 'ImportExpression' && typeof source?.value === 'string')) {
+        dependencies.push(source.value);
+      }
+    }
+  });
+
+  return dependencies;
+}
+
+/**
+ * @param {URL} sourceFile
+ * @param {URL} targetDirectory
+ */
+export default async function hashCopy(sourceFile, targetDirectory) {
+  const content = await readFile(sourceFile);
+  const hash = createHash('sha256')
+    .update(content)
+    .digest('hex');
+  const originalFilename = sourceFile.pathname.split('/').pop();
+  const parts = originalFilename.split('.');
+
+  parts[parts.length - 2] = `hashed-${parts[parts.length - 2]}-${hash}`;
+
+  const hashedFileName = parts.join('.');
+  const target = new URL(targetDirectory);
+
+  if (!target.pathname.endsWith('/')) {
+    target.pathname += '/';
+  }
+
+  target.pathname += hashedFileName;
+
+  await writeFile(target, content);
+
+  return [originalFilename, { hashedFileName, dependencies: findImports(content.toString()) }];
+}

--- a/lib/load-post-files.js
+++ b/lib/load-post-files.js
@@ -17,19 +17,74 @@ export function parseFrontMatter(raw) {
   return { attributes: JSON.parse(filtered), body };
 }
 
+function generateImportMap(baseUrl, pageUrl, scripts, hashedScripts) {
+  const resolved = new Set();
+  const queue = scripts.map(script => new URL(script.href, pageUrl).href);
+
+  while (queue.length) {
+    const url = queue.shift();
+
+    if (resolved.has(url)) {
+      continue;
+    }
+
+    const path = url.slice(baseUrl.length);
+    const { dependencies } = hashedScripts[path] || {};
+
+    for (const dependency of dependencies || []) {
+      queue.push(new URL(dependency, url).href);
+    }
+
+    resolved.add(url.slice(baseUrl.length));
+  }
+
+  const importMap = { imports: {} };
+  let count = 0;
+
+  for (const url of Array.from(resolved).sort()) {
+    const localHashed = hashedScripts[url];
+
+    if (localHashed) {
+      const referenceUrl = new URL(url, baseUrl);
+      importMap.imports[url] = new URL(localHashed.hashedFileName, referenceUrl).href.slice(baseUrl.length);
+      count++;
+    }
+  }
+
+  return count ? importMap : null;
+}
+
+function compareHashedScripts(a, b) {
+  const akeys = Object.keys(a);
+
+  if (akeys.length !== Object.keys(b).length) {
+    return false;
+  }
+
+  for (const key of akeys) {
+    if (a[key] !== b[key]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 const cache = new Map();
 
-async function loadPostFile({ fileUrl, basePath, baseUrl, repoUrl, type, extraCss }) {
+// eslint-disable-next-line max-statements
+async function loadPostFile({ fileUrl, basePath, baseUrl, repoUrl, type, extraCss, hashedScripts }) {
   const { mtimeMs } = await stat(fileUrl, { bigint: true });
   const cached = cache.get(fileUrl);
   const extraCssPaths = new Set(extraCss ? extraCss.values() : []);
 
   if (cached && cached.mtimeMs === mtimeMs && cached.styles.every(s => extraCssPaths.has(s.src))) {
-    return cached;
+    if (compareHashedScripts(cached.hashedScripts, hashedScripts)) {
+      return cached;
+    }
   }
 
   const post = await readFile(fileUrl, 'utf8');
-  const path = fileUrl.href.slice(basePath.href.length);
   const { attributes, body } = parseFrontMatter(post);
   const { title, datetime, updatedAt, tags, webmentions, draft, description, scripts = [], styles = [] } = attributes;
   const slug = attributes.slug || createSlug(title);
@@ -37,12 +92,14 @@ async function loadPostFile({ fileUrl, basePath, baseUrl, repoUrl, type, extraCs
   const content = render(body);
   const { document } = new JSDOM(content).window;
   const hasRuby = checkForRubyAnnotations(document);
-  const localUrl = `/${type}/${slug}`;
-  const canonical = `${baseUrl}${localUrl}`;
+  const canonical = `${baseUrl}/${type}/${slug}`;
   const localLinks = getLocalLinks(document, canonical, baseUrl);
+  const allScripts = hasRuby ? scripts.concat({ href: '/scripts/ruby-options.js' }) : scripts;
+  const importMap = generateImportMap(baseUrl, canonical, allScripts, hashedScripts);
 
   const digested = {
     mtimeMs,
+    hashedScripts,
     attributes,
     tags,
     body,
@@ -50,13 +107,14 @@ async function loadPostFile({ fileUrl, basePath, baseUrl, repoUrl, type, extraCs
     snippet: makeSnippet(document),
     hasRuby,
     description,
-    scripts: hasRuby ? scripts.concat({ href: '/scripts/ruby-options.js' }) : scripts,
+    scripts: allScripts.map(({ href }) => ({ href: importMap && importMap.imports[href] || href })),
+    importMap: importMap && JSON.stringify(importMap),
     styles: styles.map(({ src }) => ({ src: extraCss.get(src) })).filter(Boolean),
     webmentions,
     isBlogEntry: true,
     draft,
     slug,
-    localUrl,
+    localUrl: `/${type}/${slug}`,
     canonical,
     localLinks,
     filename: `${slug}.html`,
@@ -67,7 +125,7 @@ async function loadPostFile({ fileUrl, basePath, baseUrl, repoUrl, type, extraCs
     date,
     timestamp: date.getTime(),
     type: 'blog',
-    editUrl: `${repoUrl}/edit/main/${path}` // Assumes GitHub and main branch.
+    editUrl: `${repoUrl}/edit/main/${fileUrl.href.slice(basePath.href.length)}` // Assumes GitHub and main branch.
   };
 
   cache.set(fileUrl, digested);
@@ -76,7 +134,7 @@ async function loadPostFile({ fileUrl, basePath, baseUrl, repoUrl, type, extraCs
 }
 
 // Loads post source and metadata.
-export default async function loadPostFiles({ path, basePath, repoUrl, baseUrl, type = 'blog', extraCss = new Map() }) {
+export default async function loadPostFiles({ path, basePath, repoUrl, baseUrl, type = 'blog', extraCss = new Map(), hashedScripts }) {
   const filenames = await readdir(path);
   const posts = await Promise.all(filenames.map(fn => loadPostFile({
     fileUrl: new URL(fn, path),
@@ -84,7 +142,8 @@ export default async function loadPostFiles({ path, basePath, repoUrl, baseUrl, 
     baseUrl,
     repoUrl,
     type,
-    extraCss
+    extraCss,
+    hashedScripts
   })));
   const now = Date.now();
 

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -44,10 +44,10 @@ const year = new Date().getUTCFullYear();
 
 handlebars.registerHelper('year', () => year);
 
-handlebars.registerHelper('hash', (field, chars) => {
+handlebars.registerHelper('hash', (field, chars, encoding) => {
   return createHash('sha256')
     .update(field)
-    .digest('hex')
+    .digest(encoding || 'hex')
     .slice(0, chars);
 });
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -41,6 +41,11 @@
     X-Robots-Tag = "none"
 
 [[headers]]
+  for = "/scripts/hashed-*"
+  [headers.values]
+    Cache-Control = "max-age=315360000, public, immutable"
+
+[[headers]]
   for = "*.css"
   [headers.values]
     Cache-Control = "max-age=315360000, public, immutable"

--- a/netlify/edge-functions/add-html-security-headers.js
+++ b/netlify/edge-functions/add-html-security-headers.js
@@ -1,3 +1,5 @@
+const scriptSrcHashRegex = /^\s*<meta name="script-src-hash" content="(.*)">$/m;
+
 /* eslint-env browser */
 export default async function addHtmlSecurityHeaders(_, context) {
   /** @type Response */
@@ -7,7 +9,7 @@ export default async function addHtmlSecurityHeaders(_, context) {
 
   if (!type || type.startsWith('text/html')) {
     const body = await response.text();
-    const nonce = crypto.randomUUID();
+    const match = body.match(scriptSrcHashRegex);
 
     headers.set('strict-transport-security', 'max-age=31536000; includeSubDomains; preload');
     headers.set('x-frame-options', 'SAMEORIGIN');
@@ -15,7 +17,7 @@ export default async function addHtmlSecurityHeaders(_, context) {
     headers.set('x-content-type-options', 'nosniff');
     headers.set(
       'content-security-policy',
-      `default-src 'self'; script-src 'nonce-${nonce}' 'self'; style-src 'self'; img-src *; child-src https://www.youtube-nocookie.com 'self'; frame-src https://www.youtube-nocookie.com 'self';` // eslint-disable-line max-len
+      `default-src 'self'; script-src${match ? ` '${match[1]}'` : ''} 'self'; style-src 'self'; img-src *; child-src https://www.youtube-nocookie.com 'self'; frame-src https://www.youtube-nocookie.com 'self';` // eslint-disable-line max-len
     );
     headers.set('referrer-policy', 'strict-origin-when-cross-origin');
     headers.set('cache-control', 'no-cache');
@@ -24,7 +26,7 @@ export default async function addHtmlSecurityHeaders(_, context) {
       'accelerometer=(self), ambient-light-sensor=(self), camera=(self), fullscreen=(self), gyroscope=(self), magnetometer=(self), microphone=(self), midi=(self), picture-in-picture=(), sync-xhr=(), usb=(self), interest-cohort=()' // eslint-disable-line max-len
     );
 
-    return new Response(body.replace('%%NONCE%%', nonce), response);
+    return new Response(body, response);
   }
 
   return response;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
       "dependencies": {
         "busboy": "1.6.0",
         "cssnano": "5.1.14",
+        "espree": "^9.4.1",
+        "estraverse": "^5.3.0",
         "feedme": "^2.0.2",
         "geo-tz": "7.0.5",
         "handlebars": "^4.7.7",
@@ -248,7 +250,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -1499,7 +1500,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
       "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-      "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
@@ -1528,7 +1528,6 @@
       "version": "9.4.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
       "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
-      "dev": true,
       "dependencies": {
         "acorn": "^8.8.0",
         "acorn-jsx": "^5.3.2",
@@ -5102,7 +5101,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
       "requires": {}
     },
     "acorn-walk": {
@@ -6003,8 +6001,7 @@
     "eslint-visitor-keys": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-      "dev": true
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA=="
     },
     "esm": {
       "version": "3.2.25",
@@ -6015,7 +6012,6 @@
       "version": "9.4.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
       "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
-      "dev": true,
       "requires": {
         "acorn": "^8.8.0",
         "acorn-jsx": "^5.3.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
   "dependencies": {
     "busboy": "1.6.0",
     "cssnano": "5.1.14",
+    "espree": "^9.4.1",
+    "estraverse": "^5.3.0",
     "feedme": "^2.0.2",
     "geo-tz": "7.0.5",
     "handlebars": "^4.7.7",

--- a/src/templates/partials/head.html.handlebars
+++ b/src/templates/partials/head.html.handlebars
@@ -54,7 +54,8 @@
 {{/if}}
 <meta name="theme-color" content="#f1e7cd">
 {{#importMap}}
-<script type="importmap" nonce="%%NONCE%%">{{{this}}}</script>
+<meta name="script-src-hash" content="sha256-{{{hash this Infinity "base64"}}}">
+<script type="importmap">{{{this}}}</script>
 {{/importMap}}
 {{#dev}}
 <script>

--- a/src/templates/partials/head.html.handlebars
+++ b/src/templates/partials/head.html.handlebars
@@ -53,6 +53,9 @@
   <meta name="twitter:image:alt" content="The qubyte.codes site icon.">
 {{/if}}
 <meta name="theme-color" content="#f1e7cd">
+{{#importMap}}
+<script type="importmap" nonce="%%NONCE%%">{{{this}}}</script>
+{{/importMap}}
 {{#dev}}
 <script>
   const source = new EventSource('/events');


### PR DESCRIPTION
The one issue encountered is that the hashed scripts have to be placed in the same directory as the unhashed scripts so that local resolution using `./` works whether or not import maps are supported.

TODO: Right now every blog page gets a complete import map. It would be better to only deploy an import map with necessary resolutions in to keep page sizes down.

## Issues

The import map needs to be inline (external maps aren't supported by any browser yet), but this violates the CSP header. The options are:
- Keep building individual import maps, hash them, and add the hash to the CSP header. It may be possible to do this with a meta tag, which would be very convenient for rendering, but may not play nicely with the policy in the header. If this needs to be done per page then either the CSP edge function needs to be updated with a mapping or the netlify.toml page does. Edit: It looks like both policies would be enforced, so the server headers would block the inline import map.
- Make a single import map to be used by all pages which use scripts, and update the edge function with the one hash.