### PR TITLE
Hash the index.js entry point.

### DIFF
--- a/content/posts/2022-11-19.md
+++ b/content/posts/2022-11-19.md
@@ -1,7 +1,7 @@
 ---
 {
   "datetime": "2022-11-23T09:00:00Z",
-  "updatedAt": null,
+  "updatedAt": "2022-11-26T10:00:00Z",
   "draft": false,
   "title": "Progressively enhanced caching of JavaScript modules without bundling using import maps",
   "description": "The generative artwork and experiments in some of my pages are built atop a number of small JavaScript modules. I don't use a bundler, and they import each other using relative paths. Immutably caching them is hard because that usually means adding a hashes to file names, so when one module changes, it cascades to changes in the file names of all modules which import that module. I figured out how to add immutable caching of JS modules using import maps, without breaking anything for browsers which don't support import maps yet.",
@@ -342,6 +342,13 @@ module preloads spec allows (but does not require) the browser to resolve the
 child imports of preloaded modules, so a middle ground may be to preload just
 some modules.
 
+One small saving I make is to exclude preload links for scripts which will
+appear in script tags. This includes the `index.js` file which applies to all
+pages (mostly there to install a service worker), the entry point(s) of any
+experiments, and the ruby state persistence script on any page with ruby
+annotations. This means that most pages don't have an import map or any preload
+links.
+
 ### Interactions with the service worker
 
 When a file is served with the immutable cache-control header, it'll either be
@@ -388,11 +395,10 @@ coming to Firefox (109) this December, and it's in the Safari Technology Preview
 enhancement browsers will automatically benefit as they gain support for config
 maps.
 
-This work so far only addresses pages with JavaScript experiments on (which are
-in the minority). Most pages have an async index script and service worker, and
-neither is part of this work yet. The index script should not be hard, but the
-service worker may be more tricky (the URL of the service worker script is
-important for the running worker and its cache).
+This work so far handles all JavaScript files I deploy except for the service
+worker. The service worker may be tricky to handle (the URL of the service
+worker script is important for the running worker and its cache). I'll update
+this post as I improve coverage.
 
 For smaller applications which differ in composition from page to page (while
 sharing many source modules) I think this solution has advantages over bundling.

--- a/lib/hash-copy.js
+++ b/lib/hash-copy.js
@@ -3,7 +3,7 @@ import { createHash } from 'node:crypto';
 import { parse as esParse } from 'espree';
 import { traverse } from 'estraverse';
 
-function findImports(scriptSource) {
+function findImports(scriptSource, importerHref, publicDirectory) {
   const dependencies = [];
   const tree = esParse(scriptSource, { ecmaVersion: 2022, sourceType: 'module' });
 
@@ -13,7 +13,7 @@ function findImports(scriptSource) {
       // but when it is a plain string we can use it. It may be worth adding or
       // using an ESLint rule to enforce `import()` only receives plain strings.
       if (type === 'ImportDeclaration' || (type === 'ImportExpression' && typeof source?.value === 'string')) {
-        dependencies.push(source.value);
+        dependencies.push(new URL(source.value, importerHref).pathname.slice(publicDirectory.pathname.length - 1));
       }
     }
   });
@@ -22,10 +22,11 @@ function findImports(scriptSource) {
 }
 
 /**
+ * @param {URL} publicDirectory
  * @param {URL} sourceFile
  * @param {URL} targetDirectory
  */
-export default async function hashCopy(sourceFile, targetDirectory) {
+export default async function hashCopy(publicDirectory, sourceFile, targetDirectory) {
   const content = await readFile(sourceFile);
   const hash = createHash('sha256')
     .update(content)
@@ -36,15 +37,15 @@ export default async function hashCopy(sourceFile, targetDirectory) {
   parts[parts.length - 2] = `hashed-${parts[parts.length - 2]}-${hash}`;
 
   const hashedFileName = parts.join('.');
-  const target = new URL(targetDirectory);
-
-  if (!target.pathname.endsWith('/')) {
-    target.pathname += '/';
-  }
-
-  target.pathname += hashedFileName;
+  const target = new URL(hashedFileName, targetDirectory);
 
   await writeFile(target, content);
 
-  return [originalFilename, { hashedFileName, dependencies: findImports(content.toString()) }];
+  return [
+    new URL(originalFilename, targetDirectory).pathname.slice(publicDirectory.pathname.length - 1),
+    {
+      hashedFilePath: target.pathname.slice(publicDirectory.pathname.length - 1),
+      dependencies: findImports(content.toString(), target, publicDirectory)
+    }
+  ];
 }

--- a/lib/load-like-files.js
+++ b/lib/load-like-files.js
@@ -9,7 +9,7 @@ const makeFeedItem = handlebars
   .compile('<p>Like of <a href="{{likeOf}}">{{likeOf}}</a></p>');
 
 
-export default async function loadLikeFiles(dir) {
+export default async function loadLikeFiles(dir, _syndictions, indexJsFile) {
   const filenames = await readdir(dir);
   const notes = await Promise.all(filenames.filter(fn => fn.endsWith('.json')).map(async filename => {
     const note = await readFile(new URL(filename, dir), 'utf8');
@@ -19,6 +19,7 @@ export default async function loadLikeFiles(dir) {
     return {
       timestamp,
       localUrl: `/likes/${timestamp}`,
+      indexJsFile,
       datetime: new Date(timestamp).toISOString(),
       timezone: getTimezone(latitude, longitude),
       likeOf,

--- a/lib/load-link-files.js
+++ b/lib/load-link-files.js
@@ -8,7 +8,7 @@ const makeSnippet = handlebars
 const makeFeedItem = handlebars
   .compile('<p>{{#if content}}{{content}} {{/if}}<a href="{{href}}">{{name}}</a></p>');
 
-export default async function loadLinkFiles(dir, syndications) {
+export default async function loadLinkFiles(dir, syndications, indexJsFile) {
   const filenames = await readdir(dir);
   const notes = await Promise.all(filenames.filter(fn => fn.endsWith('.json')).map(async filename => {
     const link = await readFile(new URL(filename, dir), 'utf8');
@@ -31,6 +31,7 @@ export default async function loadLinkFiles(dir, syndications) {
       timestamp,
       timezone: getTimezone(latitude, longitude),
       localUrl: `/links/${timestamp}`,
+      indexJsFile,
       datetime: new Date(timestamp).toISOString(),
       bookmarkOf: bookmarkOf[0],
       repostOf: repostOf[0],

--- a/lib/load-note-files.js
+++ b/lib/load-note-files.js
@@ -12,7 +12,7 @@ async function fileReadable(url) {
   }
 }
 
-export default async function loadNoteFiles(dir, imagesDir, syndications, imagesDimensions) {
+export default async function loadNoteFiles({ dir, imagesDir, syndications, imagesDimensions, indexJsFile }) {
   const filenames = await readdir(dir);
   const notes = await Promise.all(filenames.filter(fn => fn.endsWith('.json')).map(async (filename, index) => {
     const note = JSON.parse(await readFile(new URL(filename, dir), 'utf8'));
@@ -57,6 +57,7 @@ export default async function loadNoteFiles(dir, imagesDir, syndications, images
     return {
       hType,
       timestamp,
+      indexJsFile,
       localUrl: `/notes/${timestamp}`,
       datetime: new Date(timestamp).toISOString(),
       timezone: getTimezone(latitude, longitude),

--- a/lib/load-post-files.js
+++ b/lib/load-post-files.js
@@ -19,23 +19,23 @@ export function parseFrontMatter(raw) {
 
 function generateImportMap(baseUrl, pageUrl, scripts, hashedScripts) {
   const resolved = new Set();
-  const queue = scripts.map(script => new URL(script.href, pageUrl).href);
+  const hrefs = scripts.map(s => s.href);
+  const queue = hrefs.map(href => new URL(href, pageUrl).pathname);
 
   while (queue.length) {
-    const url = queue.shift();
+    const path = queue.shift();
 
-    if (resolved.has(url)) {
+    if (resolved.has(path)) {
       continue;
     }
 
-    const path = url.slice(baseUrl.length);
-    const { dependencies } = hashedScripts[path] || {};
+    const { dependencies = [] } = hashedScripts[path] || {};
 
-    for (const dependency of dependencies || []) {
-      queue.push(new URL(dependency, url).href);
+    for (const dependency of dependencies) {
+      queue.push(new URL(dependency, new URL(path, baseUrl)).pathname);
     }
 
-    resolved.add(url.slice(baseUrl.length));
+    resolved.add(path);
   }
 
   const importMap = { imports: {} };
@@ -44,9 +44,8 @@ function generateImportMap(baseUrl, pageUrl, scripts, hashedScripts) {
   for (const url of Array.from(resolved).sort()) {
     const localHashed = hashedScripts[url];
 
-    if (localHashed) {
-      const referenceUrl = new URL(url, baseUrl);
-      importMap.imports[url] = new URL(localHashed.hashedFileName, referenceUrl).href.slice(baseUrl.length);
+    if (localHashed && !hrefs.includes(url)) {
+      importMap.imports[url] = localHashed.hashedFilePath;
       count++;
     }
   }
@@ -73,7 +72,7 @@ function compareHashedScripts(a, b) {
 const cache = new Map();
 
 // eslint-disable-next-line max-statements
-async function loadPostFile({ fileUrl, basePath, baseUrl, repoUrl, type, extraCss, hashedScripts }) {
+async function loadPostFile({ fileUrl, basePath, baseUrl, repoUrl, type, extraCss, hashedScripts, indexJsFile }) {
   const { mtimeMs } = await stat(fileUrl, { bigint: true });
   const cached = cache.get(fileUrl);
   const extraCssPaths = new Set(extraCss ? extraCss.values() : []);
@@ -107,7 +106,8 @@ async function loadPostFile({ fileUrl, basePath, baseUrl, repoUrl, type, extraCs
     snippet: makeSnippet(document),
     hasRuby,
     description,
-    scripts: allScripts.map(({ href }) => ({ href: importMap && importMap.imports[href] || href })),
+    indexJsFile,
+    scripts: allScripts.map(({ href }) => ({ href: hashedScripts[href]?.hashedFilePath || href })),
     importMapObject: importMap,
     importMap: importMap && JSON.stringify(importMap),
     styles: styles.map(({ src }) => ({ src: extraCss.get(src) })).filter(Boolean),
@@ -135,7 +135,16 @@ async function loadPostFile({ fileUrl, basePath, baseUrl, repoUrl, type, extraCs
 }
 
 // Loads post source and metadata.
-export default async function loadPostFiles({ path, basePath, repoUrl, baseUrl, type = 'blog', extraCss = new Map(), hashedScripts }) {
+export default async function loadPostFiles({
+  path,
+  basePath,
+  repoUrl,
+  baseUrl,
+  type = 'blog',
+  extraCss = new Map(),
+  hashedScripts,
+  indexJsFile
+}) {
   const filenames = await readdir(path);
   const posts = await Promise.all(filenames.map(fn => loadPostFile({
     fileUrl: new URL(fn, path),
@@ -144,7 +153,8 @@ export default async function loadPostFiles({ path, basePath, repoUrl, baseUrl, 
     repoUrl,
     type,
     extraCss,
-    hashedScripts
+    hashedScripts,
+    indexJsFile
   })));
   const now = Date.now();
 

--- a/lib/load-reply-files.js
+++ b/lib/load-reply-files.js
@@ -5,7 +5,7 @@ import getTimezone from './get-timezone.js';
 const makeSnippet = handlebars.compile('<p>{{content}}</p>');
 const makeFeedItem = handlebars.compile('<p>{{content}}</p>');
 
-export default async function loadReplyFiles(dir) {
+export default async function loadReplyFiles(dir, indexJsFile) {
   const filenames = await readdir(dir);
   const notes = await Promise.all(filenames.filter(fn => fn.endsWith('.json')).map(async filename => {
     const note = await readFile(new URL(filename, dir), 'utf8');
@@ -15,6 +15,7 @@ export default async function loadReplyFiles(dir) {
     return {
       timestamp,
       localUrl: `/replies/${timestamp}`,
+      indexJsFile,
       datetime: new Date(timestamp).toISOString(),
       timezone: getTimezone(latitude, longitude),
       content,

--- a/lib/load-study-session-files.js
+++ b/lib/load-study-session-files.js
@@ -17,7 +17,7 @@ function formatDuration(duration) {
   return `${duration.minutes}m`;
 }
 
-export default async function loadStudySessionsFiles(dir) {
+export default async function loadStudySessionsFiles(dir, indexJsFile) {
   const filenames = await readdir(dir);
   const sessions = await Promise.all(filenames.filter(fn => fn.endsWith('.json')).map(async (filename, index) => {
     const session = JSON.parse(await readFile(new URL(filename, dir), 'utf8'));
@@ -32,6 +32,7 @@ export default async function loadStudySessionsFiles(dir) {
     return {
       hType,
       timestamp,
+      indexJsFile,
       localUrl: `/study-sessions/${timestamp}`,
       timezone: getTimezone(latitude, longitude),
       filename: `${timestamp}.html`,

--- a/netlify.toml
+++ b/netlify.toml
@@ -41,6 +41,11 @@
     X-Robots-Tag = "none"
 
 [[headers]]
+  for = "/hashed-*"
+  [headers.values]
+    Cache-Control = "max-age=315360000, public, immutable"
+
+[[headers]]
   for = "/scripts/hashed-*"
   [headers.values]
     Cache-Control = "max-age=315360000, public, immutable"

--- a/src/templates/partials/head.html.handlebars
+++ b/src/templates/partials/head.html.handlebars
@@ -12,7 +12,10 @@
 {{#importMapObject}}
 {{#each imports}}<link rel="modulepreload" href="{{this}}">{{/each}}
 {{/importMapObject}}
-<script src="/index.js" async></script>
+<script src="{{indexJsFile}}" async></script>
+{{#scripts}}
+<script src="{{{href}}}" type="module"></script>
+{{/scripts}}
 <link href="{{cssPath}}" rel="stylesheet">
 {{#styles}}
 <link href="{{src}}" rel="stylesheet">
@@ -73,6 +76,3 @@
   window.onbeforeunload = () => source.close();
 </script>
 {{/dev}}
-{{#each scripts}}
-<script src="{{{href}}}" type="module"></script>
-{{/each}}


### PR DESCRIPTION
Also omit all entry points from the import maps. They're naturally discovered as regular scripts as the browser parses the HTML.