### PR TITLE
Triggers reloading and rehashing when JS experiment files change.

### DIFF
--- a/index.js
+++ b/index.js
@@ -383,7 +383,10 @@ export async function build({ baseUrl, baseTitle, repoUrl, dev, syndications }) 
         const items = (await readdir(directory)).filter(i => i.endsWith('.js'));
         const entries = await Promise.all(items.map(item => hashCopy(target, new URL(item, directory), scriptsTarget)));
 
-        return Object.fromEntries(entries);
+        return ExecutionGraph.createWatchableResult({
+          path: directory,
+          result: Object.fromEntries(entries)
+        });
       }
     },
     papersTarget: {


### PR DESCRIPTION
Prior to this change, a server reload was needed to trigger rehashing of JS and rebuilding of posts.