### PR TITLE
Offloads most image conversion and uploading to an action.

### DIFF
--- a/.github/workflows/micropub-media-conversion.yml
+++ b/.github/workflows/micropub-media-conversion.yml
@@ -1,0 +1,36 @@
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'content/images/*-original.jpeg'
+jobs:
+  get-added-files:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@main
+      with:
+        fetch-depth: 2
+    - name: Get added JPEGs
+      run: echo "::set-output name=jpeg::$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep original.jpeg$ | xargs)"
+  convert-jpegs:
+    needs: get-added-files
+    steps:
+    - name: checkout
+      uses: actions/checkout@main
+    - name: use node 16
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16.x
+    - run: npm ci
+    - name: Convert JPEGs
+      run: node scripts/convert-jpegs.js ${{needs.get-added-files.outputs.jpeg}}
+    - name: Push
+      run: |
+          date > generated.txt
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add content/images
+          git commit -m "Image conversions for ${{needs.get-added-files.outputs.jpeg}}\n\n[skip ci]"
+          git push

--- a/functions/micropub-media.js
+++ b/functions/micropub-media.js
@@ -26,7 +26,7 @@ export async function handler(event) {
     console.log('PLAIN FILE UPLOAD OF ', contentType, event.isBase64Encoded);
 
     const content = event.isBase64Encoded ? Buffer.from(event.body, 'base64') : event.body;
-    const path = await uploadImage({ content });
+    const path = await uploadImage({ content, type: contentType });
 
     console.log('path', path);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "marked": "^4.2.4",
         "mathjax-full": "^3.2.2",
         "node-fetch": "3.3.0",
-        "p-queue": "^7.3.0",
         "p-retry": "5.1.2",
         "postcss": "8.4.20",
         "postcss-calc": "8.2.4",
@@ -1505,11 +1504,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
-    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -2751,21 +2745,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-queue": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.3.0.tgz",
-      "integrity": "sha512-5fP+yVQ0qp0rEfZoDTlP2c3RYBgxvRsw30qO+VtPPc95lyvSG+x6USSh1TuLB4n96IO6I8/oXQGsTgtna4q2nQ==",
-      "dependencies": {
-        "eventemitter3": "^4.0.7",
-        "p-timeout": "^5.0.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/p-retry": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-5.1.2.tgz",
@@ -2776,17 +2755,6 @@
       },
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-timeout": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
-      "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==",
-      "engines": {
-        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5650,11 +5618,6 @@
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "dev": true
     },
-    "eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
-    },
     "expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -6548,15 +6511,6 @@
         "p-limit": "^3.0.2"
       }
     },
-    "p-queue": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.3.0.tgz",
-      "integrity": "sha512-5fP+yVQ0qp0rEfZoDTlP2c3RYBgxvRsw30qO+VtPPc95lyvSG+x6USSh1TuLB4n96IO6I8/oXQGsTgtna4q2nQ==",
-      "requires": {
-        "eventemitter3": "^4.0.7",
-        "p-timeout": "^5.0.2"
-      }
-    },
     "p-retry": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-5.1.2.tgz",
@@ -6565,11 +6519,6 @@
         "@types/retry": "0.12.1",
         "retry": "^0.13.1"
       }
-    },
-    "p-timeout": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
-      "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew=="
     },
     "parent-module": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "marked": "^4.2.4",
     "mathjax-full": "^3.2.2",
     "node-fetch": "3.3.0",
-    "p-queue": "^7.3.0",
     "p-retry": "5.1.2",
     "postcss": "8.4.20",
     "postcss-calc": "8.2.4",

--- a/scripts/convert-jpegs.js
+++ b/scripts/convert-jpegs.js
@@ -1,0 +1,30 @@
+import sharp from 'sharp';
+import { join } from 'node:path';
+
+const paths = process.argv.slice(2);
+const results = [];
+
+function convertTo(fullPath, width, format, name) {
+  return sharp(fullPath)
+    .rotate()
+    .resize(width)
+    .toFormat(format)
+    .toFile(name)
+    .then(() => console.log('generated', name)); // eslint-disable-line no-console
+}
+
+for (const path of paths) {
+  const fullPath = join(process.cwd(), path);
+
+  console.log('Converting:', fullPath); // eslint-disable-line no-console
+
+  results.push(
+    convertTo(fullPath, 1600, 'avif', fullPath.replace('-original.jpeg', '-2x.avif')),
+    convertTo(fullPath, 800, 'avif', fullPath.replace('-original.jpeg', '.avif')),
+    convertTo(fullPath, 1600, 'webp', fullPath.replace('-original.jpeg', '-2x.webp')),
+    convertTo(fullPath, 800, 'webp', fullPath.replace('-original.jpeg', '.webp')),
+    convertTo(fullPath, 800, 'jpeg', fullPath.replace('-original.jpeg', '.jpeg'))
+  );
+}
+
+await Promise.all(results);


### PR DESCRIPTION
AVIF conversion takes long enough that it busts the 10s netlify function timeout. This PR updates the function to upload the file directly to GitHub, where an Actions workflow will convert JPEGs to AVIF and WebP images (and a 800px wide fallback JPEG).