### PR TITLE
Don't run CI on non-js and non-json pushes.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: CI
 on:
   push:
+    paths:
+    - '.github/workflows/ci.yml'
+    - '**.js'
+    - '**.eslintrc.json'
+    - 'package.json'
+    - 'package-lock.json'
     branches:
     - main
   pull_request:


### PR DESCRIPTION
Most pushes are study sessions and simple content, which shouldn't trigger CI. This change tries to ensure CI is only triggered when one or more of these conditions is satisfied:

- One or more JS files are modified.
- The package file is changed.
- The package lock file is changed.
- The CI configuration is changed.
- An ESLint configuration is changed.