### PR TITLE
Defer use of index.js in the execution graph until rendering.

### DIFF
--- a/lib/load-like-files.js
+++ b/lib/load-like-files.js
@@ -9,7 +9,7 @@ const makeFeedItem = handlebars
   .compile('<p>Like of <a href="{{likeOf}}">{{likeOf}}</a></p>');
 
 
-export default async function loadLikeFiles(dir, _syndictions, indexJsFile) {
+export default async function loadLikeFiles(dir) {
   const filenames = await readdir(dir);
   const notes = await Promise.all(filenames.filter(fn => fn.endsWith('.json')).map(async filename => {
     const note = await readFile(new URL(filename, dir), 'utf8');
@@ -19,7 +19,6 @@ export default async function loadLikeFiles(dir, _syndictions, indexJsFile) {
     return {
       timestamp,
       localUrl: `/likes/${timestamp}`,
-      indexJsFile,
       datetime: new Date(timestamp).toISOString(),
       timezone: getTimezone(latitude, longitude),
       likeOf,

--- a/lib/load-link-files.js
+++ b/lib/load-link-files.js
@@ -8,7 +8,7 @@ const makeSnippet = handlebars
 const makeFeedItem = handlebars
   .compile('<p>{{#if content}}{{content}} {{/if}}<a href="{{href}}">{{name}}</a></p>');
 
-export default async function loadLinkFiles(dir, syndications, indexJsFile) {
+export default async function loadLinkFiles(dir, syndications) {
   const filenames = await readdir(dir);
   const notes = await Promise.all(filenames.filter(fn => fn.endsWith('.json')).map(async filename => {
     const link = await readFile(new URL(filename, dir), 'utf8');
@@ -31,7 +31,6 @@ export default async function loadLinkFiles(dir, syndications, indexJsFile) {
       timestamp,
       timezone: getTimezone(latitude, longitude),
       localUrl: `/links/${timestamp}`,
-      indexJsFile,
       datetime: new Date(timestamp).toISOString(),
       bookmarkOf: bookmarkOf[0],
       repostOf: repostOf[0],

--- a/lib/load-note-files.js
+++ b/lib/load-note-files.js
@@ -12,7 +12,7 @@ async function fileReadable(url) {
   }
 }
 
-export default async function loadNoteFiles({ dir, imagesDir, syndications, imagesDimensions, indexJsFile }) {
+export default async function loadNoteFiles({ dir, imagesDir, syndications, imagesDimensions }) {
   const filenames = await readdir(dir);
   const notes = await Promise.all(filenames.filter(fn => fn.endsWith('.json')).map(async (filename, index) => {
     const note = JSON.parse(await readFile(new URL(filename, dir), 'utf8'));
@@ -57,7 +57,6 @@ export default async function loadNoteFiles({ dir, imagesDir, syndications, imag
     return {
       hType,
       timestamp,
-      indexJsFile,
       localUrl: `/notes/${timestamp}`,
       datetime: new Date(timestamp).toISOString(),
       timezone: getTimezone(latitude, longitude),

--- a/lib/load-post-files.js
+++ b/lib/load-post-files.js
@@ -63,7 +63,7 @@ function compareHashedScripts(a, b) {
 const cache = new Map();
 
 // eslint-disable-next-line max-statements
-async function loadPostFile({ fileUrl, basePath, baseUrl, repoUrl, type, extraCss, hashedScripts, indexJsFile }) {
+async function loadPostFile({ fileUrl, basePath, baseUrl, repoUrl, type, extraCss, hashedScripts }) {
   const { mtimeMs } = await stat(fileUrl, { bigint: true });
   const cached = cache.get(fileUrl);
   const extraCssPaths = new Set(extraCss ? extraCss.values() : []);
@@ -97,7 +97,6 @@ async function loadPostFile({ fileUrl, basePath, baseUrl, repoUrl, type, extraCs
     snippet: makeSnippet(document),
     hasRuby,
     description,
-    indexJsFile,
     scripts: allScripts.map(({ href }) => ({ href: hashedScripts[href]?.hashedFilePath || href })),
     importMapObject: importMap,
     importMap: importMap && JSON.stringify(importMap),
@@ -133,8 +132,7 @@ export default async function loadPostFiles({
   baseUrl,
   type = 'blog',
   extraCss = new Map(),
-  hashedScripts,
-  indexJsFile
+  hashedScripts
 }) {
   const filenames = await readdir(path);
   const posts = await Promise.all(filenames.map(fn => loadPostFile({
@@ -144,8 +142,7 @@ export default async function loadPostFiles({
     repoUrl,
     type,
     extraCss,
-    hashedScripts,
-    indexJsFile
+    hashedScripts
   })));
   const now = Date.now();
 

--- a/lib/load-reply-files.js
+++ b/lib/load-reply-files.js
@@ -5,7 +5,7 @@ import getTimezone from './get-timezone.js';
 const makeSnippet = handlebars.compile('<p>{{content}}</p>');
 const makeFeedItem = handlebars.compile('<p>{{content}}</p>');
 
-export default async function loadReplyFiles(dir, indexJsFile) {
+export default async function loadReplyFiles(dir) {
   const filenames = await readdir(dir);
   const notes = await Promise.all(filenames.filter(fn => fn.endsWith('.json')).map(async filename => {
     const note = await readFile(new URL(filename, dir), 'utf8');
@@ -15,7 +15,6 @@ export default async function loadReplyFiles(dir, indexJsFile) {
     return {
       timestamp,
       localUrl: `/replies/${timestamp}`,
-      indexJsFile,
       datetime: new Date(timestamp).toISOString(),
       timezone: getTimezone(latitude, longitude),
       content,

--- a/lib/load-study-session-files.js
+++ b/lib/load-study-session-files.js
@@ -17,7 +17,7 @@ function formatDuration(duration) {
   return `${duration.minutes}m`;
 }
 
-export default async function loadStudySessionsFiles(dir, indexJsFile) {
+export default async function loadStudySessionsFiles(dir) {
   const filenames = await readdir(dir);
   const sessions = await Promise.all(filenames.filter(fn => fn.endsWith('.json')).map(async (filename, index) => {
     const session = JSON.parse(await readFile(new URL(filename, dir), 'utf8'));
@@ -32,7 +32,6 @@ export default async function loadStudySessionsFiles(dir, indexJsFile) {
     return {
       hType,
       timestamp,
-      indexJsFile,
       localUrl: `/study-sessions/${timestamp}`,
       timezone: getTimezone(latitude, longitude),
       filename: `${timestamp}.html`,


### PR DESCRIPTION
Before, the index.js was passed into the file loaders. There was no reason to do this though, since it's only used for rendering.

There may be a small benefit to average first compile time with this change, since the graph no longer has to wait for the index.js file to be buffered before reading posts, replies, etc.