### PR TITLE
Update syndications handling.

### DIFF
--- a/functions/micropub.js
+++ b/functions/micropub.js
@@ -18,19 +18,6 @@ async function getTitle(url) {
 function syndications() {
   return [
     {
-      uid: 'https://twitter.com/qubyte',
-      name: 'qubyte on twitter',
-      service: {
-        name: 'Twitter',
-        url: 'https://twitter.com/'
-      },
-      user: {
-        name: 'qubyte',
-        url: 'https://twitter.com/qubyte',
-        photo: 'https://pbs.twimg.com/profile_images/958386895037267968/K7X2jWDU.jpg'
-      }
-    },
-    {
       uid: 'https://mastodon.social/@qubyte',
       name: 'qubyte on mastodon.social',
       service: {

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ function makeWriteEntries({ renderedDependencies, pathFragment }) {
 
 // This is where it all kicks off. This function loads posts and templates,
 // renders it all to files, and saves them to the public directory.
-export async function build({ baseUrl, baseTitle, repoUrl, dev, syndications }) {
+export async function build({ baseUrl, baseTitle, repoUrl, dev }) {
   const basePath = new URL('./', import.meta.url);
   const sourcePath = new URL('./src/', import.meta.url);
   const contentPath = new URL('./content/', import.meta.url);
@@ -89,13 +89,10 @@ export async function build({ baseUrl, baseTitle, repoUrl, dev, syndications }) 
     templates: {
       dependencies: ['paths'],
       async action({ paths: { source } }) {
-        const templatesPath = new URL('templates/', source);
-        const templates = await loadTemplates(templatesPath, { baseTitle });
+        const path = new URL('templates/', source);
+        const result = await loadTemplates(path, { baseTitle });
 
-        return ExecutionGraph.createWatchableResult({
-          path: templatesPath,
-          result: templates
-        });
+        return ExecutionGraph.createWatchableResult({ path, result });
       }
     },
     feeds: {
@@ -153,7 +150,7 @@ export async function build({ baseUrl, baseTitle, repoUrl, dev, syndications }) 
 
         return ExecutionGraph.createWatchableResult({
           path: dir,
-          result: await loadNoteFiles({ dir, imagesDir, syndications, imagesDimensions })
+          result: await loadNoteFiles({ dir, imagesDir, imagesDimensions })
         });
       }
     },
@@ -175,7 +172,7 @@ export async function build({ baseUrl, baseTitle, repoUrl, dev, syndications }) 
 
         return ExecutionGraph.createWatchableResult({
           path: linksPath,
-          result: await loadLinkFiles(linksPath, syndications)
+          result: await loadLinkFiles(linksPath)
         });
       }
     },
@@ -186,7 +183,7 @@ export async function build({ baseUrl, baseTitle, repoUrl, dev, syndications }) 
 
         return ExecutionGraph.createWatchableResult({
           path: likesPath,
-          result: await loadLikeFiles(likesPath, syndications)
+          result: await loadLikeFiles(likesPath)
         });
       }
     },
@@ -462,12 +459,12 @@ export async function build({ baseUrl, baseTitle, repoUrl, dev, syndications }) 
     robotsFile: {
       dependencies: ['paths'],
       async action({ paths: { source, target } }) {
-        const verificationPath = new URL('robots.txt', source);
+        const robotsPath = new URL('robots.txt', source);
 
-        await copyFile(verificationPath, new URL('robots.txt', target));
+        await copyFile(robotsPath, new URL('robots.txt', target));
 
         return ExecutionGraph.createWatchableResult({
-          path: verificationPath,
+          path: robotsPath,
           result: null
         });
       }

--- a/lib/load-link-files.js
+++ b/lib/load-link-files.js
@@ -8,7 +8,7 @@ const makeSnippet = handlebars
 const makeFeedItem = handlebars
   .compile('<p>{{#if content}}{{content}} {{/if}}<a href="{{href}}">{{name}}</a></p>');
 
-export default async function loadLinkFiles(dir, syndications) {
+export default async function loadLinkFiles(dir) {
   const filenames = await readdir(dir);
   const notes = await Promise.all(filenames.filter(fn => fn.endsWith('.json')).map(async filename => {
     const link = await readFile(new URL(filename, dir), 'utf8');
@@ -18,13 +18,11 @@ export default async function loadLinkFiles(dir, syndications) {
         'repost-of': repostOf = [],
         name = [],
         content = [],
-        'mp-syndicate-to': rawSyndications,
         latitude,
         longitude
       }
     } = JSON.parse(link);
     const timestamp = parseInt(filename, 10);
-    const filteredSyndications = [].concat(rawSyndications).filter(Boolean);
     const href = bookmarkOf[0] || repostOf[0];
 
     return {
@@ -39,10 +37,6 @@ export default async function loadLinkFiles(dir, syndications) {
       feedItem: makeFeedItem({ content, href, name }),
       title: `Link to ${href}`,
       snippet: makeSnippet({ content, href, name }),
-      syndications: {
-        twitter: filteredSyndications.includes(syndications.twitter),
-        mastodon: filteredSyndications.includes(syndications.mastodon)
-      },
       type: 'link',
       filename: `${timestamp}.html`
     };

--- a/lib/load-note-files.js
+++ b/lib/load-note-files.js
@@ -12,13 +12,12 @@ async function fileReadable(url) {
   }
 }
 
-export default async function loadNoteFiles({ dir, imagesDir, syndications, imagesDimensions }) {
+export default async function loadNoteFiles({ dir, imagesDir, imagesDimensions }) {
   const filenames = await readdir(dir);
   const notes = await Promise.all(filenames.filter(fn => fn.endsWith('.json')).map(async (filename, index) => {
     const note = JSON.parse(await readFile(new URL(filename, dir), 'utf8'));
-    const { type: [hType], properties: { photo, 'mp-syndicate-to': rawSyndications, latitude, longitude } } = note;
+    const { type: [hType], properties: { photo, latitude, longitude } } = note;
     const timestamp = parseInt(filename, 10);
-    const filteredSyndications = [].concat(rawSyndications).filter(Boolean);
 
     const [body] = note.properties.content;
     const content = render(body);
@@ -60,10 +59,6 @@ export default async function loadNoteFiles({ dir, imagesDir, syndications, imag
       localUrl: `/notes/${timestamp}`,
       datetime: new Date(timestamp).toISOString(),
       timezone: getTimezone(latitude, longitude),
-      syndications: {
-        twitter: filteredSyndications.includes(syndications.twitter),
-        mastodon: filteredSyndications.includes(syndications.mastodon)
-      },
       filename: `${timestamp}.html`,
       type: 'note',
       content,

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -3,13 +3,9 @@ import { build } from '../index.js';
 const baseUrl = process.env.CONTEXT !== 'production' ? process.env.DEPLOY_URL : process.env.URL;
 const baseTitle = process.env.BASE_TITLE;
 const repoUrl = new URL(process.env.REPOSITORY_URL);
-const syndications = {
-  mastodon: process.env.MASTODON_SYNDICATION,
-  twitter: process.env.TWITTER_SYNDICATION
-};
 
 try {
-  await build({ baseUrl, baseTitle, repoUrl, syndications });
+  await build({ baseUrl, baseTitle, repoUrl });
 } catch (e) {
   console.error(e);
   process.exit(1);

--- a/scripts/serve.js
+++ b/scripts/serve.js
@@ -9,10 +9,6 @@ import { build } from '../index.js';
 
 const notFoundUrl = new URL('../public/404.html', import.meta.url);
 const port = 8080;
-const syndications = {
-  mastodon: 'https://mastodon.social/@qubyte',
-  twitter: 'https://twitter.com/qubyte'
-};
 
 // This watches the content of the src directory for any changes, triggering a
 // build each time a change happens.
@@ -26,7 +22,6 @@ try {
     baseUrl: `http://localhost:${port}`,
     repoUrl: new URL('https://github.com/qubyte/qubyte-codes'),
     baseTitle: 'DEV MODE',
-    syndications,
     dev: true
   });
 } catch (error) {

--- a/src/templates/partials/link.html.handlebars
+++ b/src/templates/partials/link.html.handlebars
@@ -6,8 +6,6 @@
   {{#if bookmarkOf}}
   <p class="e-content">
     {{content}}
-    {{#if syndications.twitter}}<a class="mention-of" href="https://brid.gy/publish/twitter"></a>{{/if}}
-    {{#if syndications.mastodon}}<a class="mention-of" href="https://brid.gy/publish/mastodon"></a>{{/if}}
   </p>
   <a class="u-bookmark-of p-name" href="{{bookmarkOf}}">{{name}}</a>
   {{else if repostOf}}

--- a/src/templates/partials/note.html.handlebars
+++ b/src/templates/partials/note.html.handlebars
@@ -5,8 +5,6 @@
   </header>
   <div class="e-content">
     {{{content}}}
-    {{#if syndications.twitter}}<a class="mention-of" href="https://brid.gy/publish/twitter"></a>{{/if}}
-    {{#if syndications.mastodon}}<a class="mention-of" href="https://brid.gy/publish/mastodon"></a>{{/if}}
   </div>
   {{#photos}}
     <picture>


### PR DESCRIPTION
Bridgy no longer does my syndications, so I can remove some markup it needed. I'm also no longer syndicating to twitter, so I've removed some lingering config from the micropub config endpoint.

At the moment this is ignored and all notes get syndicated. In the future I need to figure out how to do checkboxes or something similar in Apple shortcuts.