### PR TITLE
Updates conclusion of import maps post.

### DIFF
--- a/content/posts/2022-11-19.md
+++ b/content/posts/2022-11-19.md
@@ -1,7 +1,7 @@
 ---
 {
   "datetime": "2022-11-23T09:00:00Z",
-  "updatedAt": "2022-11-26T10:00:00Z",
+  "updatedAt": "2023-04-01T14:30:00Z",
   "draft": false,
   "title": "Progressively enhanced caching of JavaScript modules without bundling using import maps",
   "description": "The generative artwork and experiments in some of my pages are built atop a number of small JavaScript modules. I don't use a bundler, and they import each other using relative paths. Immutably caching them is hard because that usually means adding a hashes to file names, so when one module changes, it cascades to changes in the file names of all modules which import that module. I figured out how to add immutable caching of JS modules using import maps, without breaking anything for browsers which don't support import maps yet.",
@@ -390,11 +390,9 @@ also mean all resources are already cached, and no further requests are needed.
 
 ### Conclusion and future work
 
-Chrome is currently the only browser with support for import maps, but it's
-coming to Firefox (109) this December, and it's in the Safari Technology Preview
-(so hopefully the not too distant future). As this work is a progressive
-enhancement browsers will automatically benefit as they gain support for import
-maps.
+When I first published this article, the only browsers to support import maps
+were those based on Chrome. Firefox shipped support about a month after, and
+finally Safari in March 2023. The big browsers now all support import maps!
 
 This work so far handles all JavaScript files I deploy except for the service
 worker. The service worker may be tricky to handle (the URL of the service


### PR DESCRIPTION
The major browsers now all support import maps.