### PR TITLE
Replaces mathjax rendering to svg with temml rendering to mathml

### DIFF
--- a/content/posts/2018-01-02.md
+++ b/content/posts/2018-01-02.md
@@ -22,9 +22,9 @@ avoid brute forcing the answer.
 
 At this point in the challenges, writing a parser for an input file is something
 I'll skip over. The parser gives back an array of objects, each representing a
-particle, with `p`, `v`, and `a` fields to represent position, velocity, and
+particle, with $p$, $v$, and $a$ fields to represent position, velocity, and
 acceleration respectively. These quantities are all represented as length three
-arrays for the x, y, and z axes. The input looks like:
+arrays for the $x$, $y$, and $z$ axes. The input looks like:
 
 ```json
 [
@@ -75,7 +75,7 @@ for (let i = 0; i < input.length - 1; i++) {
 
 I've used the index of each particle in the input array as its ID for
 convenience. The snippet grabs all pairs and uses the function `collisionTime`,
-which returns either an integer (time of their first collision from `t=0`), or
+which returns either an integer (time of their first collision from $t=0$), or
 `null` if they never collide. The `collisions` array is indexed by time step,
 and populated with arrays of collisions. I'll come back to `collisionTime`
 later, because that's where interesting things happen.
@@ -127,7 +127,7 @@ to properly count these, particle IDs to be removed are held in the `toDelete`
 set and removed after all collisions at a given time step have been checked.
 
 Let's go back to the function `collisionTime`. For a given pair of particle
-objects, it determines when their first collision is beginning at `t=0`. Here's
+objects, it determines when their first collision is beginning at $t=0$. Here's
 a naïve implementation:
 
 ```javascript
@@ -226,9 +226,9 @@ $$
 
 Where the delta signifies a difference (the above is the equation of one
 particle subtracted from the equation for a another particle). The solutions for
-`t` I want are when the left hand side (difference in position at time step `t`)
+$t$ I want are when the left hand side (difference in position at time step $t$)
 is zero. To avoid a division and retain integers as long as possible, I multiply
-both sides by two and rewrite slightly to collect powers of `t`.
+both sides by two and rewrite slightly to collect powers of $t$.
 
 $$
 0 = \Delta a t^2 + \left(2\Delta v_0 + \Delta a\right) t + 2\Delta p_0
@@ -250,11 +250,11 @@ $$
 where
 
 $$
-\begin{split}
+\begin{align}
 a &= \Delta a \\
 b &= 2\Delta v_0 + \Delta a \\
 c &= 2\Delta p_0
-\end{split}
+\end{align}
 $$
 
 I'm interested in solutions which are [natural numbers][5] (real positive
@@ -283,10 +283,10 @@ function solveQuadratic(a, b, c) {
 }
 ```
 
-The function `isNaturalNumber` uses the right bitshift operator. This is a trick
-to get an integer out of a number. Positive numbers will be floored, negative
-numbers will overflow (become large positive integers), and `NaN` will become
-zero. Only positive integers will pass the strict equality check.
+The function `isNaturalNumber` uses the right bit shift operator. This is a
+trick to get an integer out of a number. Positive numbers will be floored,
+negative numbers will overflow (become large positive integers), and `NaN` will
+become zero. Only positive integers will pass the strict equality check.
 `solveQuadratic` itself encodes the solution to both the linear case
 (acceleration of zero) and the quadratic case. JavaScript is on our side here
 with how it represents numbers.

--- a/content/posts/2019-12-02.md
+++ b/content/posts/2019-12-02.md
@@ -26,7 +26,7 @@ this on my memory of an image of a piece in [a talk by][talk]
 pen and paper plotter (which I love), but I lack these tools at present, so I
 chose to use the browser instead (lucky you).
 
-In hindsight I should have realised that the domains around points are like a
+In hindsight, I should have realized that the domains around points are like a
 [Voronoi diagram][voronoi]. I forged ahead having forgotten all about them, so
 please excuse my unorthodox terminology below. Looking back on [the talk][talk]
 that inspired this, my memory of the drawing wasn't quite correct. See the real
@@ -34,8 +34,8 @@ deal at about [6:25][625] in.
 
 Based on my memory, the image was of a number of points. From each point lines
 (I'll call these spokes) radiated outwards until they reached the edge of the
-domain of a point. The "domain" as I call it is an area aroud a point bounded by
-the half way lines between it and neighbouring points, or the bounding box of
+domain of a point. The "domain" as I call it is an area around a point bounded
+by the half way lines between it and neighbouring points, or the bounding box of
 the image.
 
 The case of neighbouring points looks like:
@@ -72,18 +72,19 @@ $$
 y(x) - y_0 = \frac{x_0 - x_1}{y_0 - y_1} (x - x_0)
 $$
 
-Where the numeric subscripts `0` and `1` are for the two points, and we're
-interested in the spokes radiating from point `0`.
+Where the numeric subscripts $0$ and $1$ are for the two points, and we're
+interested in the spokes radiating from point $0$.
 
-Any two fixed points on the line can be used to place the line. For example it's
-just as valid to use the coordinates of the second point (note the subscripts):
+Any two fixed points on the line can be used to place the line. For example,
+it's just as valid to use the coordinates of the second point (note the
+subscripts):
 
 $$
 y(x) - y_1 = \frac{x_0 - x_1}{y_0 - y_1} (x - x_1)
 $$
 
-The equation for a the boundary line is perpendicular to the point-to-point line
-and half way along it. Since the lines cross half-way along the point-to-point
+The equation for the boundary line is perpendicular to the point-to-point line
+and halfway along it. Since the lines cross half-way along the point-to-point
 line, we can use that location to fix the perpendicular line:
 
 $$
@@ -107,10 +108,10 @@ With the equation for a boundary, I needed an equation for each spoke. My intent
 was to use these simultaneous equations to find the solution for the length of
 the spoke.
 
-The equation for the boundary line is in Cartesian coordinates `(x, y)`, but
-given that we have an angle and we're looking for a length, it's more natural to
-think of a spoke in polar coordinates `(r, Θ)`. In fact, taking the point as the
-origin, `r` is the length we're actually looking for.
+The equation for the boundary line is in Cartesian coordinates $(x, y)$, but
+given that we have an angle, and we're looking for a length, it's more natural
+to think of a spoke in polar coordinates $(r, Θ)$. In fact, taking the point as
+the origin, $r$ is the length we're actually looking for.
 
 A line in polar coordinates can be connected to Cartesian coordinates using the
 following equations:
@@ -128,10 +129,10 @@ $$
 r \sin \theta + y_0 = \frac{x_1 - x_0}{y_0 - y_1}\left(r \cos \theta + \frac{x_0 - x_1}{2}\right) + \frac{y_0 + y_1}{2}
 $$
 
-After some rearranging, the solution for `r` looks like:
+After some rearranging, the solution for $r$ looks like:
 
 $$
-r = \frac{1}{2} \frac{(y_1 - y_0)^2 + (x_1 - x_0)^2}{(y_1 - y_0)\sin \theta + (x_1 - x_0) \cos \theta}
+r = \frac{1}{2} \cdot \frac{(y_1 - y_0)^2 + (x_1 - x_0)^2}{(y_1 - y_0)\sin \theta + (x_1 - x_0) \cos \theta}
 $$
 
 Since the equations for the bounding box edges are more simple:
@@ -157,9 +158,9 @@ r &= \frac{y_{max} - y_0}{\sin\theta}
 $$
 
 Given all these equations, for each spoke radiating from each point we need to
-calculate `r` for boundaries with every other point and also the bounding box.
-Spokes radiate _away_ from a point, so all negative values of `r` can be
-discarded. Of the remaining possible values of `r`, the shortest wins!
+calculate $r$ for boundaries with every other point and also the bounding box.
+Spokes radiate _away_ from a point, so all negative values of $r$ can be
+discarded. Of the remaining possible values of $r$, the shortest wins!
 
 I settled on using 10 randomly placed points, each with 48 evenly spaced spokes.
 I've added a gap between spoke ends (both with their point and the boundary) to

--- a/content/posts/2022-05-13.md
+++ b/content/posts/2022-05-13.md
@@ -1,7 +1,7 @@
 ---
 {
   "datetime": "2022-05-15T10:55:00+01:00",
-  "updatedAt": null,
+  "updatedAt": "2023-06-20T00:20:00+01:00",
   "draft": false,
   "title": "Marqdown",
   "description": "I've added so many tweaks and extensions to the markdown flavour I use for this site now that I've decided to document them, and give the whole a name.",
@@ -180,11 +180,14 @@ to render the maths statically to avoid client side rendering (and all the JS
 I'd have to include to do that).
 
 I settled on another common markdown extension to do this, which is to embed
-LaTeX code. The previous extensions are all inline, whereas maths blocks are
-blocks. I use [MathJax] to render LaTeX within the maths blocks to SVG. The
-resultant SVG has some inline style and unnecessary attributes stripped out,
-and a title and title added with an `aria-labelledby` to point to the title for
-accessibility purposes.
+LaTeX code. The previous extensions are all inline, whereas maths comes both in
+inline and block contexts. I use [temml] to render LaTeX directly to
+presentational MathML. Inline mode uses single `$` symbols as delimiters, and
+blocks use double `$$` on their own lines above and below the content.
+
+In the past I used [MathJax]. Visually the `SVG` MathJax produces is superior to
+MathML, but the latter is now acceptable, and `<math>` elements are more
+appropriate than `<svg>`, and much less bulky.
 
 This:
 
@@ -200,11 +203,9 @@ $$
 x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}
 $$
 
-Nice, right? If you hover over it a tooltip will show you the original LaTeX
-code. I haven't figured out inline maths snippets yet.
-
 [marked]: https://marked.js.org/
 [cjk-render]: https://heistak.github.io/your-code-displays-japanese-wrong/
 [ruby]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ruby
+[temml]: https://temml.org
 [MathJax]: https://www.mathjax.org/
 [furigana]: https://en.wikipedia.org/wiki/Furigana

--- a/lib/render.js
+++ b/lib/render.js
@@ -2,20 +2,8 @@ import highlightjs from 'highlight.js';
 import { marked } from 'marked';
 import { gfmHeadingId } from 'marked-gfm-heading-id';
 import { markedHighlight } from 'marked-highlight';
-import { mathjax } from 'mathjax-full/js/mathjax.js';
-import { TeX } from 'mathjax-full/js/input/tex.js';
-import { SVG } from 'mathjax-full/js/output/svg.js';
-import { jsdomAdaptor } from 'mathjax-full/js/adaptors/jsdomAdaptor.js';
-import { RegisterHTMLHandler as registerHtmlHandler } from 'mathjax-full/js/handlers/html.js';
-import { AllPackages } from 'mathjax-full/js/input/tex/AllPackages.js';
+import temml from 'temml/dist/temml.mjs';
 import { JSDOM } from 'jsdom';
-
-registerHtmlHandler(jsdomAdaptor(JSDOM));
-
-const texToSvg = mathjax.document('', {
-  InputJax: new TeX({ packages: AllPackages }),
-  OutputJax: new SVG({ fontCache: 'local', internalSpeechTitles: true })
-});
 
 /**
  * The lang-span markdown extension introduces spans with language attributes.
@@ -180,32 +168,19 @@ marked.use(
         renderer(token) {
           this.parser.options.equation++;
 
-          // MathJax renders LaTeX to SVG via JSDOM. I make some modifications
-          // before stringifying it to SVG text.
+          const html = temml.renderToString(token.inner, {
+            throwOnError: true,
+            displayMode: true,
+            annotate: true
+          });
+          const { window } = new JSDOM(html);
 
-          const id = `equation-${this.parser.options.equation}`;
-          const node = texToSvg.convert(token.inner, { display: true, containerWidth: 800 });
-          /** @type SVGSVGElement */
-          const svg = node.firstChild;
+          const math = window.document.querySelector('math');
+          math.id = `equation-${this.parser.options.equation}`;
+          math.setAttribute('aria-label', token.inner.trim());
+          math.removeAttribute('style');
 
-          // Remove unnecessary attributes.
-          svg.removeAttribute('style');
-          svg.removeAttribute('xmlns');
-          svg.removeAttribute('xmlns:xlink');
-
-          // Add a class for CSS to hook onto.
-          svg.classList.add('mathematics');
-
-          // Point the aria-labelledby attribute to the title (see below).
-          svg.setAttribute('aria-labelledby', id);
-
-          // Add a title element for tool-tips and accessibility.
-          const title = texToSvg.adaptor.document.createElement('title');
-          title.id = id;
-          title.append(token.inner);
-          svg.prepend(title);
-
-          return svg.outerHTML;
+          return math.outerHTML;
         }
       },
       {

--- a/lib/render.js
+++ b/lib/render.js
@@ -207,6 +207,10 @@ marked.use(
           math.setAttribute('aria-label', token.inner.trim());
           math.removeAttribute('style');
 
+          for (const el of math.querySelectorAll('[style]')) {
+            el.removeAttribute('style');
+          }
+
           return math.outerHTML;
         }
       },

--- a/lib/render.js
+++ b/lib/render.js
@@ -145,6 +145,33 @@ marked.use(
         }
       },
       {
+        name: 'maths-inline',
+        level: 'inline',
+        start(src) {
+          return src.match(/\$/)?.index;
+        },
+        tokenizer(src) {
+          if (!src.startsWith('$')) {
+            return;
+          }
+
+          const nextIndex = src.indexOf('$', 1);
+
+          if (nextIndex !== -1) {
+            return {
+              type: 'maths-inline',
+              raw: src.slice(0, nextIndex + 1)
+            };
+          }
+        },
+        renderer(tokens) {
+          return temml.renderToString(tokens.raw.slice(1, tokens.raw.length - 1), {
+            throwOnError: true,
+            displayMode: false
+          });
+        }
+      },
+      {
         name: 'maths-block',
         level: 'block',
         start(src) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,11 +23,11 @@
         "marked": "^5.0.5",
         "marked-gfm-heading-id": "^3.0.4",
         "marked-highlight": "^2.0.1",
-        "mathjax-full": "^3.2.2",
         "postcss": "8.4.24",
         "postcss-import": "^15.1.0",
         "sharp": "0.32.1",
-        "slugify": "1.6.6"
+        "slugify": "1.6.6",
+        "temml": "^0.10.13"
       },
       "devDependencies": {
         "@toisu/static": "4.1.0",
@@ -1278,14 +1278,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/espree": {
       "version": "9.5.2",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.2.tgz",
@@ -2188,26 +2180,10 @@
         "marked": "^4 || ^5"
       }
     },
-    "node_modules/mathjax-full": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/mathjax-full/-/mathjax-full-3.2.2.tgz",
-      "integrity": "sha512-+LfG9Fik+OuI8SLwsiR02IVdjcnRCy5MufYLi0C3TdMT56L/pjB0alMVGgoWJF8pN9Rc7FESycZB9BMNWIid5w==",
-      "dependencies": {
-        "esm": "^3.2.25",
-        "mhchemparser": "^4.1.0",
-        "mj-context-menu": "^0.6.1",
-        "speech-rule-engine": "^4.0.6"
-      }
-    },
     "node_modules/mdn-data": {
       "version": "2.0.30",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
       "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
-    },
-    "node_modules/mhchemparser": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/mhchemparser/-/mhchemparser-4.1.1.tgz",
-      "integrity": "sha512-R75CUN6O6e1t8bgailrF1qPq+HhVeFTM3XQ0uzI+mXTybmphy3b6h4NbLOYhemViQ3lUs+6CKRkC3Ws1TlYREA=="
     },
     "node_modules/mime": {
       "version": "1.6.0",
@@ -2279,11 +2255,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/mj-context-menu": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.6.1.tgz",
-      "integrity": "sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA=="
     },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
@@ -3597,27 +3568,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/speech-rule-engine": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-4.0.7.tgz",
-      "integrity": "sha512-sJrL3/wHzNwJRLBdf6CjJWIlxC04iYKkyXvYSVsWVOiC2DSkHmxsqOhEeMsBA9XK+CHuNcsdkbFDnoUfAsmp9g==",
-      "dependencies": {
-        "commander": "9.2.0",
-        "wicked-good-xpath": "1.3.0",
-        "xmldom-sre": "0.1.31"
-      },
-      "bin": {
-        "sre": "bin/sre"
-      }
-    },
-    "node_modules/speech-rule-engine/node_modules/commander": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.2.0.tgz",
-      "integrity": "sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==",
-      "engines": {
-        "node": "^12.20.0 || >=14"
-      }
-    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -3784,6 +3734,14 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/temml": {
+      "version": "0.10.13",
+      "resolved": "https://registry.npmjs.org/temml/-/temml-0.10.13.tgz",
+      "integrity": "sha512-tW7MGueYNp/TEqYl1gEJLzov98Z6wQlZQ0VQ7xdGD4qzSKC2W5d05KmI66PGqDHEqbGXPrG2a/nynkni/G9AVA==",
+      "engines": {
+        "node": ">=18.13.0"
       }
     },
     "node_modules/text-encoding": {
@@ -4065,11 +4023,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/wicked-good-xpath": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz",
-      "integrity": "sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw=="
-    },
     "node_modules/word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -4135,14 +4088,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
-    },
-    "node_modules/xmldom-sre": {
-      "version": "0.1.31",
-      "resolved": "https://registry.npmjs.org/xmldom-sre/-/xmldom-sre-0.1.31.tgz",
-      "integrity": "sha512-f9s+fUkX04BxQf+7mMWAp5zk61pciie+fFLC9hX9UVvCeJQfNHRHXpeo5MPcR0EUf57PYLdt+ZO4f3Ipk2oZUw==",
-      "engines": {
-        "node": ">=0.1"
-      }
     },
     "node_modules/yallist": {
       "version": "4.0.0",
@@ -5027,11 +4972,6 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
       "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA=="
     },
-    "esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
-    },
     "espree": {
       "version": "9.5.2",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.2.tgz",
@@ -5695,26 +5635,10 @@
       "integrity": "sha512-LDUfR/zDvD+dJ+lQOWHkxvBLNxiXcaN8pBtwJ/i4pI0bkDC/Ef6Mz1qUrAuHXfnpdr2rabdMpVFhqFuU+5Mskg==",
       "requires": {}
     },
-    "mathjax-full": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/mathjax-full/-/mathjax-full-3.2.2.tgz",
-      "integrity": "sha512-+LfG9Fik+OuI8SLwsiR02IVdjcnRCy5MufYLi0C3TdMT56L/pjB0alMVGgoWJF8pN9Rc7FESycZB9BMNWIid5w==",
-      "requires": {
-        "esm": "^3.2.25",
-        "mhchemparser": "^4.1.0",
-        "mj-context-menu": "^0.6.1",
-        "speech-rule-engine": "^4.0.6"
-      }
-    },
     "mdn-data": {
       "version": "2.0.30",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
       "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
-    },
-    "mhchemparser": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/mhchemparser/-/mhchemparser-4.1.1.tgz",
-      "integrity": "sha512-R75CUN6O6e1t8bgailrF1qPq+HhVeFTM3XQ0uzI+mXTybmphy3b6h4NbLOYhemViQ3lUs+6CKRkC3Ws1TlYREA=="
     },
     "mime": {
       "version": "1.6.0",
@@ -5759,11 +5683,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
       "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
-    },
-    "mj-context-menu": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.6.1.tgz",
-      "integrity": "sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA=="
     },
     "mkdirp-classic": {
       "version": "0.5.3",
@@ -6646,23 +6565,6 @@
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
     },
-    "speech-rule-engine": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-4.0.7.tgz",
-      "integrity": "sha512-sJrL3/wHzNwJRLBdf6CjJWIlxC04iYKkyXvYSVsWVOiC2DSkHmxsqOhEeMsBA9XK+CHuNcsdkbFDnoUfAsmp9g==",
-      "requires": {
-        "commander": "9.2.0",
-        "wicked-good-xpath": "1.3.0",
-        "xmldom-sre": "0.1.31"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "9.2.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-9.2.0.tgz",
-          "integrity": "sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w=="
-        }
-      }
-    },
     "statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -6783,6 +6685,11 @@
         "inherits": "^2.0.3",
         "readable-stream": "^3.1.1"
       }
+    },
+    "temml": {
+      "version": "0.10.13",
+      "resolved": "https://registry.npmjs.org/temml/-/temml-0.10.13.tgz",
+      "integrity": "sha512-tW7MGueYNp/TEqYl1gEJLzov98Z6wQlZQ0VQ7xdGD4qzSKC2W5d05KmI66PGqDHEqbGXPrG2a/nynkni/G9AVA=="
     },
     "text-encoding": {
       "version": "0.6.4",
@@ -6984,11 +6891,6 @@
         "isexe": "^2.0.0"
       }
     },
-    "wicked-good-xpath": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz",
-      "integrity": "sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw=="
-    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -7031,11 +6933,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
-    },
-    "xmldom-sre": {
-      "version": "0.1.31",
-      "resolved": "https://registry.npmjs.org/xmldom-sre/-/xmldom-sre-0.1.31.tgz",
-      "integrity": "sha512-f9s+fUkX04BxQf+7mMWAp5zk61pciie+fFLC9hX9UVvCeJQfNHRHXpeo5MPcR0EUf57PYLdt+ZO4f3Ipk2oZUw=="
     },
     "yallist": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -35,11 +35,11 @@
     "marked": "^5.0.5",
     "marked-gfm-heading-id": "^3.0.4",
     "marked-highlight": "^2.0.1",
-    "mathjax-full": "^3.2.2",
     "postcss": "8.4.24",
     "postcss-import": "^15.1.0",
     "sharp": "0.32.1",
-    "slugify": "1.6.6"
+    "slugify": "1.6.6",
+    "temml": "^0.10.13"
   },
   "devDependencies": {
     "@toisu/static": "4.1.0",

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -30,6 +30,89 @@ math[display="block"] {
   text-align: center;
 }
 
+mtable.tml-jot > mtr > mtd {
+  padding-top: calc(0.5ex + 0.09em);
+  padding-bottom: calc(0.5ex + 0.09em);
+}
+
+/* Zero column gap for {alignat}, {split}, etc */
+mtable.tml-abut > mtr > mtd,
+mtable.tml-align > mtr > mtd:nth-child(odd),
+mtable.tml-align-star > mtr > mtd:nth-child(even) {
+  padding-left: 0em;
+  padding-right: 0em;
+}
+
+mtable.tml-align > mtr > mtd:nth-child(even),
+mtable.tml-align-star > mtr > mtd:nth-child(odd) {
+  padding-left: 1em;
+  padding-right: 0em;
+}
+
+mtable.tml-align > mtr > mtd:nth-child(1) {
+  padding-left: 0em;
+}
+
+mtable.tml-align > mtr > mtd:nth-child(odd),
+mtable.tml-alignat > mtr > mtd:nth-child(odd),
+mtable.tml-aligned > mtr > mtd:nth-child(even) {
+  text-align: -webkit-left;
+  text-align: -moz-left;
+  text-align: left;
+}
+
+mtable.tml-align > mtr > mtd:nth-child(even),
+mtable.tml-alignat > mtr > mtd:nth-child(even),
+mtable.tml-aligned > mtr > mtd:nth-child(odd) {
+  text-align: -webkit-right;
+  text-align: -moz-right;
+  text-align: right;
+}
+
+mtable.tml-cases > mtr > mtd {
+  padding-left: 0em;
+  padding-right: 0em;
+  text-align: -webkit-left;
+  text-align: -moz-left;
+}
+
+mtable.tml-cases > mtr > mtd:nth-child(2) {
+  padding-left: 1em;
+}
+
+mtable.tml-small > mtr > mtd {
+  padding-top: 0.35ex;
+  padding-bottom: 0.35ex;
+  padding-left: 0.1389em;
+  padding-right: 0.1389em;
+}
+
+mtable.tml-subarray > mtr > mtd {
+  padding-top: 0em;
+  padding-left: 0em;
+}
+
+mtable.tml-cd > mtr > mtd {
+  padding-left: 0.25em;
+  padding-right: 0.25em;
+}
+
+mtable > mtr:first-child > mtr > mtd {
+  padding-top: 0em;
+}
+
+mtable > mtr:last-child > mtr > mtd {
+  padding-bottom: 0em;
+}
+
+mtable:not(.tml-array) > mtr > mtd:first-child {
+  padding-left: 0em;
+}
+
+mtable:not(.tml-array) > mtr > mtd:last-child {
+  padding-right: 0em;
+}
+
 body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   text-align: left;

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -12,6 +12,24 @@
   --standout-color-alt: hsl(calc(var(--base-foreground-hue) - 30), var(--base-foreground-sat), var(--base-foreground-lum));
 }
 
+math {
+  direction: ltr;
+  text-indent: 0px;
+  letter-spacing: normal;
+  line-height: normal;
+  word-spacing: normal;
+  font-style: normal;
+  font-weight: normal;
+  -webkit-line-box-contain: glyphs replaced;
+  font-family: "Latin Modern Math", "STIX Two Math", "XITS Math", "STIX Math", "Libertinus Math", "TeX Gyre Termes Math", "TeX Gyre Bonum Math", "TeX Gyre Schola", "DejaVu Math TeX Gyre", "TeX Gyre Pagella Math", "Asana Math", "Cambria Math", "Lucida Bright Math", "Minion Math", STIXGeneral, STIXSizeOneSym, Symbol, "Times New Roman", serif;
+  writing-mode: horizontal-tb;
+}
+
+math[display="block"] {
+  display: block math;
+  text-align: center;
+}
+
 body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   text-align: left;

--- a/tests/units/render.test.js
+++ b/tests/units/render.test.js
@@ -16,17 +16,15 @@ describe('render', () => {
     assert.equal(rendered.trim(), '<p>a paragraph</p>');
   });
 
-  it('renders $$ delimited blocks labelled as SVG in the img role and a title containing the original maths', () => {
+  it('renders $$ delimited blocks labelled as math with an annotation containing original maths', () => {
     const rendered = render('$$\na=b\n$$', URL);
 
     const { window: { document } } = new JSDOM(rendered);
-    const $svg = document.querySelector('svg');
+    const $math = document.querySelector('math');
 
-    assert.equal($svg.getAttribute('role'), 'img');
+    const $original = $math.querySelector('annotation[encoding="application/x-tex"]');
 
-    const $title = $svg.querySelector('title');
-
-    assert.equal($title.textContent, 'a=b');
+    assert.equal($original.textContent, 'a=b');
   });
 
   describe('mathematics with dollar delimiters', () => {
@@ -35,37 +33,36 @@ describe('render', () => {
 
       const { window: { document } } = new JSDOM(rendered);
 
-      assert.equal(document.querySelectorAll('svg[style]').length, 0);
+      assert.equal(document.querySelectorAll('math[style]').length, 0);
     });
 
     it('updates the ID of the title of the rendered mathematics', () => {
       const rendered = render('$$\na=b\n$$', URL);
 
       const { window: { document } } = new JSDOM(rendered);
-      const titles = document.querySelectorAll('svg title[id]');
+      const math = document.querySelector('math');
 
-      assert.equal(titles.length, 1);
-      assert.equal(titles[0].id, 'equation-1');
+      assert.equal(math.id, 'equation-1');
     });
 
     it('increments the title ID to avoid collisions', () => {
       const rendered = render('$$\na=b\n$$\n\ntext\n\n$$\nc=d\n$$', URL);
       const { window: { document } } = new JSDOM(rendered);
-      const titles = document.querySelectorAll('svg title[id]');
+      const maths = document.querySelectorAll('math');
 
-      assert.equal(titles.length, 2);
-      assert.equal(titles[0].id, 'equation-1');
-      assert.equal(titles[1].id, 'equation-2');
+      assert.equal(maths.length, 2);
+      assert.equal(maths[0].id, 'equation-1');
+      assert.equal(maths[1].id, 'equation-2');
     });
 
-    it('sets aria-labelledby to the title element ID for each snipped', () => {
+    it('sets aria-label to the original math for each snipped', () => {
       const rendered = render('$$\na=b\n$$\n\ntext\n\n$$\nc=d\n$$', URL);
 
       const { window: { document } } = new JSDOM(rendered);
-      const svgs = document.querySelectorAll('svg');
+      const maths = document.querySelectorAll('math');
 
-      assert.equal(svgs[0].getAttribute('aria-labelledby'), 'equation-1');
-      assert.equal(svgs[1].getAttribute('aria-labelledby'), 'equation-2');
+      assert.equal(maths[0].getAttribute('aria-label'), 'a=b');
+      assert.equal(maths[1].getAttribute('aria-label'), 'c=d');
     });
   });
 

--- a/tests/units/render.test.js
+++ b/tests/units/render.test.js
@@ -66,6 +66,12 @@ describe('render', () => {
     });
   });
 
+  describe('inline mathematics with single dollar delimiters', () => {
+    const rendered = render('hello $a$ world', URL);
+
+    assert.equal(rendered.trim(), '<p>hello <math><mi>a</mi></math> world</p>');
+  });
+
   describe('inline ruby links', () => {
     it('renders ruby elements', () => {
       const rendered = render('^買,か,いに,,行,い,く,^', URL).trim();


### PR DESCRIPTION
- Replace MathJax statically rendering to SVG with temml (KaTeX fork) statically rendering to presentational MathML.
- Add static rendering of inline (single dollar) maths.

MathML rendering has reached the point of being acceptable, and it's both lighter over the wire and more semantically appropriate.