### PR TITLE
Replace cache-control header injected by the security-header edge function

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,19 +2,11 @@
   publish = "public"
   command = "npm run build"
 
+[build.processing]
+  skip_processing = true
+
 [build.processing.html]
   pretty_urls = true
-
-[build.processing.images]
-  compress = false
-
-[build.processing.css]
-  bundle = false
-  minify = false
-
-[build.processing.js]
-  bundle = false
-  minify = false
 
 [build.environment]
   NODE_ENV = "production"

--- a/netlify/edge-functions/add-html-security-headers.js
+++ b/netlify/edge-functions/add-html-security-headers.js
@@ -26,7 +26,7 @@ export default async function addHtmlSecurityHeaders(_, context) {
       `default-src 'self'; script-src${match ? ` '${match[1]}'` : ''} 'self'; style-src 'self'; img-src *; child-src https://www.youtube-nocookie.com 'self'; frame-src https://www.youtube-nocookie.com 'self';` // eslint-disable-line max-len
     );
     headers.set('referrer-policy', 'strict-origin-when-cross-origin');
-    headers.set('cache-control', 'no-cache');
+    headers.set('cache-control', 'max-age=0, s-maxage=31536000');
     headers.set(
       'permissions-policy',
       'accelerometer=(self), ambient-light-sensor=(self), camera=(self), fullscreen=(self), gyroscope=(self), magnetometer=(self), microphone=(self), midi=(self), picture-in-picture=(), sync-xhr=(), usb=(self), interest-cohort=()' // eslint-disable-line max-len


### PR DESCRIPTION
This allows better caching in two ways:

1. The client is now allowed to use a cached document without first revalidating it.
2. The netlify cache sees a long `s-max-age` value.

The netlify cache is cleared [after each deployment][0], so the effect is that responses are cached once per document, per deployment.

[0]: https://docs.netlify.com/edge-functions/optional-configuration/#supported-headers