### PR TITLE
Adds deletion actions to execution graph node

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,15 @@ function makeWriteEntries({ renderedDependencies, pathFragment }) {
   };
 }
 
+function writeRendered(renderedName, path) {
+  return {
+    dependencies: ['paths', renderedName],
+    action(config) {
+      return writeFile(new URL(path, config.paths.target), config[renderedName]);
+    }
+  };
+}
+
 async function copyStaticDirectory(sourceDirectory, targetDirectory, allowedFileEndings) {
   await cp(sourceDirectory, targetDirectory, {
     filter(src) {
@@ -678,84 +687,19 @@ export async function build({ baseUrl, baseTitle, repoUrl, dev }) {
         };
       }
     },
-    writtenIndex: {
-      dependencies: ['paths', 'renderedAbout'],
-      action({ paths: { target }, renderedAbout }) {
-        return writeFile(new URL('index.html', target), renderedAbout);
-      }
-    },
-    writtenBlogIndex: {
-      dependencies: ['paths', 'renderedBlogIndex'],
-      action({ paths: { target }, renderedBlogIndex }) {
-        return writeFile(new URL('blog/index.html', target), renderedBlogIndex);
-      }
-    },
-    writtenJapaneseNotesIndex: {
-      dependencies: ['paths', 'renderedJapaneseNotesIndex'],
-      action({ paths: { target }, renderedJapaneseNotesIndex }) {
-        return writeFile(new URL('japanese-notes/index.html', target), renderedJapaneseNotesIndex);
-      }
-    },
-    writtenNotesIndex: {
-      dependencies: ['paths', 'renderedNotesIndex'],
-      action({ paths: { target }, renderedNotesIndex }) {
-        return writeFile(new URL('notes/index.html', target), renderedNotesIndex);
-      }
-    },
-    writtenStudySessionsIndex: {
-      dependencies: ['paths', 'renderedStudySessionsIndex'],
-      action({ paths: { target }, renderedStudySessionsIndex }) {
-        return writeFile(new URL('study-sessions/index.html', target), renderedStudySessionsIndex);
-      }
-    },
-    writtenLinksIndex: {
-      dependencies: ['paths', 'renderedLinksIndex'],
-      action({ paths: { target }, renderedLinksIndex }) {
-        return writeFile(new URL('links/index.html', target), renderedLinksIndex);
-      }
-    },
-    writtenLikesIndex: {
-      dependencies: ['paths', 'renderedLikesIndex'],
-      action({ paths: { target }, renderedLikesIndex }) {
-        return writeFile(new URL('likes/index.html', target), renderedLikesIndex);
-      }
-    },
-    writtenRepliesIndex: {
-      dependencies: ['paths', 'renderedRepliesIndex'],
-      action({ paths: { target }, renderedRepliesIndex }) {
-        return writeFile(new URL('replies/index.html', target), renderedRepliesIndex);
-      }
-    },
-    writtenPublications: {
-      dependencies: ['paths', 'renderedPublications'],
-      action({ paths: { target }, renderedPublications }) {
-        return writeFile(new URL('publications.html', target), renderedPublications);
-      }
-    },
-    writtenWebmentionConfirmation: {
-      dependencies: ['paths', 'renderedWebmentionConfirmation'],
-      action({ paths: { target }, renderedWebmentionConfirmation }) {
-        return writeFile(new URL('webmention.html', target), renderedWebmentionConfirmation);
-      }
-    },
-    writtenFourOhFour: {
-      dependencies: ['paths', 'renderedFourOhFour'],
-      action({ paths: { target }, renderedFourOhFour }) {
-        return writeFile(new URL('404.html', target), renderedFourOhFour);
-      }
-    },
-    writtenSitemap: {
-      dependencies: ['paths', 'renderedSitemap'],
-      action({ paths: { target }, renderedSitemap }) {
-        return writeFile(new URL('sitemap.txt', target), renderedSitemap);
-      }
-    },
-    writtenShortlinks: {
-      dependencies: ['paths', 'renderedShortlinks'],
-      action({ paths: { target }, renderedShortlinks }) {
-        return writeFile(new URL('shortlinks.txt', target), renderedShortlinks);
-      }
-    },
+    writtenIndex: writeRendered('renderedAbout', 'index.html'),
+    writtenBlogIndex: writeRendered('renderedBlogIndex', 'blog/index.html'),
+    writtenJapaneseNotesIndex: writeRendered('renderedJapaneseNotesIndex', 'japanese-notes/index.html'),
+    writtenNotesIndex: writeRendered('renderedNotesIndex', 'notes/index.html'),
+    writtenStudySessionsIndex: writeRendered('renderedStudySessionsIndex', 'study-sessions/index.html'),
+    writtenLinksIndex: writeRendered('renderedLinksIndex', 'links/index.html'),
+    writtenLikesIndex: writeRendered('renderedLikesIndex', 'likes/index.html'),
+    writtenRepliesIndex: writeRendered('renderedRepliesIndex', 'replies/index.html'),
+    writtenPublications: writeRendered('renderedPublications', 'publications.html'),
+    writtenWebmentionConfirmation: writeRendered('renderedWebmentionConfirmation', 'webmention.html'),
+    writtenFourOhFour: writeRendered('renderedFourOhFour', '404.html'),
+    writtenSitemap: writeRendered('renderedSitemap', 'sitemap.txt'),
+    writtenShortlinks: writeRendered('renderedShortlinks', 'shortlinks.txt'),
     writtenAtomFeeds: {
       dependencies: ['paths', 'renderedAtomFeeds'],
       action({ paths: { target }, renderedAtomFeeds: { all, posts, social } }) {

--- a/lib/execution-graph.js
+++ b/lib/execution-graph.js
@@ -58,8 +58,8 @@ export default class ExecutionGraph extends EventEmitter {
     }
   }
 
-  async addNode({ name, action, dependencies = [] }) {
-    const node = { action, dependencies, done: false };
+  async addNode({ name, action, onRemove, dependencies = [] }) {
+    const node = { action, onRemove, dependencies, done: false };
 
     if (dependencies.includes(name)) {
       throw new Error('Node may not depend on itself.');
@@ -87,16 +87,18 @@ export default class ExecutionGraph extends EventEmitter {
   }
 
   addNodes(nodes) {
-    const processNode = ([name, { action, dependencies }]) => {
-      return this.addNode({ name, action, dependencies })
+    const processNode = ([name, { action, onRemove, dependencies }]) => {
+      return this.addNode({ name, action, onRemove, dependencies })
         .then(result => [name, result]);
     };
 
     return Promise.all(Object.entries(nodes).map(processNode)).then(Object.fromEntries);
   }
 
-  removeNode({ name }) {
-    if (!this.nodes.has(name)) {
+  async removeNode({ name }) {
+    const node = this.nodes.get(name);
+
+    if (!node) {
       return;
     }
 
@@ -110,6 +112,10 @@ export default class ExecutionGraph extends EventEmitter {
 
     if (dependents.length) {
       throw new Error(`Node ${name} has dependent nodes: ${dependents.join(', ')}`);
+    }
+
+    if (node.onRemove) {
+      await node.onRemove();
     }
 
     this.nodes.delete(name);
@@ -133,9 +139,9 @@ export default class ExecutionGraph extends EventEmitter {
   // TODO: This is very clunky. There's probably a more elegant way.
   // eslint-disable-next-line max-statements
   async rerunNode({ name }) {
-    const { action, dependencies } = this.nodes.get(name);
+    const node = this.nodes.get(name);
     const dependents = this.getDirectDependents({ name });
-    const collected = new Map([[name, { action, dependencies, dependents }]]);
+    const collected = new Map([[name, { node, dependents }]]);
 
     let oldSize;
     let newSize;
@@ -147,10 +153,9 @@ export default class ExecutionGraph extends EventEmitter {
       for (const { dependents } of collected.values()) {
         for (const name of dependents) {
           if (!collected.has(name)) {
-            const { action, dependencies } = this.nodes.get(name);
+            const node = this.nodes.get(name);
             collected.set(name, {
-              action,
-              dependencies,
+              node,
               dependents: this.getDirectDependents({ name })
             });
           }
@@ -172,9 +177,12 @@ export default class ExecutionGraph extends EventEmitter {
       }
     }
 
+    // Run cleanup for nodes which need it.
+    await Promise.all([...collected].map(([, { node }]) => node.onRemove && node.onRemove()));
+
     // Re-add the nodes.
     const results = await Promise.all(
-      [...collected].map(([name, { action, dependencies }]) => this.addNode({ name, action, dependencies }))
+      [...collected].map(([name, { node: { action, onRemove, dependencies } }]) => this.addNode({ name, action, onRemove, dependencies }))
     );
 
     this.emit('rerun');


### PR DESCRIPTION
This allows a node to manage teardown for itself.

This PR also uses this new capability with the CSS node, so it can clean up its own compiled file on re-run.