### PR TITLE
Allow a custom CSP header per blog post.

### DIFF
--- a/content/posts/2016-04-06.md
+++ b/content/posts/2016-04-06.md
@@ -5,7 +5,10 @@
   "description": "I gave a presentation on promises, async-await, and a server framework called Toisu! which uses them.",
   "tags": [
     "JavaScript"
-  ]
+  ],
+  "customHeaders": {
+    "Content-Security-Policy": "default-src 'self'; img-src *; child-src https://www.youtube-nocookie.com 'self'; frame-src https://www.youtube-nocookie.com 'self';"
+  }
 }
 ---
 Just before Christmas I gave a presentation on the upcoming async-await JavaScript language feature,

--- a/lib/netlify-headers.js
+++ b/lib/netlify-headers.js
@@ -5,7 +5,7 @@ function htmlHeaders() {
     ['X-Frame-Options', 'SAMEORIGIN'],
     ['X-Xss-Protection', '1'],
     ['X-Content-Type-Options', 'nosniff'],
-    ['Content-Security-Policy', 'default-src \'self\'; script-src \'self\'; style-src \'self\'; img-src *; child-src https://www.youtube-nocookie.com \'self\'; frame-src https://www.youtube-nocookie.com \'self\';'],
+    ['Content-Security-Policy', 'default-src \'self\'; img-src *;'],
     ['Referrer-Policy', 'strict-origin-when-cross-origin'],
     ['Cache-Control', 'max-age=0'],
     ['Permissions-Policy', 'accelerometer=(self), ambient-light-sensor=(self), camera=(self), fullscreen=(self), gyroscope=(self), magnetometer=(self), microphone=(self), midi=(self), picture-in-picture=(), sync-xhr=(), usb=(self), interest-cohort=()']


### PR DESCRIPTION
This allows me to trim the existing CSP header of the youtube-nocookie domains, and have it just on the one page which uses it.