### PR TITLE
Refactorings

### DIFF
--- a/lib/generate-import-map.js
+++ b/lib/generate-import-map.js
@@ -1,0 +1,36 @@
+// @ts-check
+
+/**
+ * @param {URL} pageUrl
+ * @param {{href: String}[]} scripts
+ * @param {Record<String, import('./hash-copy.js').HashCopiedPath>} hashedScripts
+ */
+export default function generateImportMap(pageUrl, scripts, hashedScripts) {
+  /** @type {Set<string>} */
+  const resolved = new Set();
+  const hrefs = scripts.map(s => s.href);
+  const queue = hrefs.map(href => new URL(href, pageUrl).pathname);
+
+  for (let path = queue.shift(); path; path = queue.shift()) {
+    if (!resolved.has(path)) {
+      for (const dependency of hashedScripts[path]?.dependencies || []) {
+        queue.push(new URL(dependency, new URL(path, pageUrl)).pathname);
+      }
+      resolved.add(path);
+    }
+  }
+
+  const importMap = { imports: {} };
+  let count = 0;
+
+  for (const url of Array.from(resolved).sort()) {
+    const localHashed = hashedScripts[url];
+
+    if (localHashed && !hrefs.includes(url)) {
+      importMap.imports[url] = localHashed.hashedFilePath;
+      count++;
+    }
+  }
+
+  return count ? importMap : null;
+}

--- a/lib/get-local-links.js
+++ b/lib/get-local-links.js
@@ -1,11 +1,19 @@
-export default function getLocalLinks(document, fromUrl, baseUrl) {
+// @ts-check
+
+/** @param {Document} document */
+export default function getLocalLinks(document) {
+  /** @type {Set<string>} */
   const localLinks = new Set();
+  const baseUrl = new URL('/', document.URL);
 
   for (const { href } of document.querySelectorAll('a')) {
-    const normalized = new URL(href, fromUrl);
+    const normalized = new URL(href, document.URL);
+    const pathname = normalized.pathname;
+    normalized.search = '';
+    normalized.hash = '';
 
-    if (normalized.href.startsWith(baseUrl)) {
-      localLinks.add(normalized.pathname);
+    if (document.URL !== normalized.href && normalized.href.startsWith(baseUrl.href)) {
+      localLinks.add(pathname);
     }
   }
 

--- a/lib/hash-copy.js
+++ b/lib/hash-copy.js
@@ -1,19 +1,39 @@
+// @ts-check
+
 import { readFile, writeFile } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
 import { parse as esParse } from 'espree';
 import { traverse } from 'estraverse';
 
-function findImports(scriptSource, importerHref, publicDirectory) {
-  const dependencies = [];
-  const tree = esParse(scriptSource, { ecmaVersion: 2022, sourceType: 'module' });
+export class HashCopiedPath {
+  /**
+   * @param {string} hashedFilePath
+   * @param {Iterable<string>} dependencies
+   */
+  constructor(hashedFilePath, dependencies) {
+    this.hashedFilePath = hashedFilePath;
+    this.dependencies = new Set(dependencies);
+  }
+}
 
-  traverse(tree, {
-    enter({ type, source }) {
+/**
+ * @param {string} scriptSource
+ * @param {string|URL} importerUrl
+ * @param {URL} publicDirectory
+ */
+function findImports(scriptSource, importerUrl, publicDirectory) {
+  /** @type {Set<string>} */
+  const dependencies = new Set();
+
+  traverse(esParse(scriptSource, { ecmaVersion: 2022, sourceType: 'module' }), {
+    enter(node) {
       // The target of an import expression can't always be known statically,
       // but when it is a plain string we can use it. It may be worth adding or
       // using an ESLint rule to enforce `import()` only receives plain strings.
-      if (type === 'ImportDeclaration' || (type === 'ImportExpression' && typeof source?.value === 'string')) {
-        dependencies.push(new URL(source.value, importerHref).pathname.slice(publicDirectory.pathname.length - 1));
+      if (node.type === 'ImportDeclaration' || node.type === 'ImportExpression') {
+        if (node.source.type === 'Literal' && typeof node.source.value === 'string') {
+          dependencies.add(new URL(node.source.value, importerUrl).pathname.slice(publicDirectory.pathname.length - 1));
+        }
       }
     }
   });
@@ -25,13 +45,14 @@ function findImports(scriptSource, importerHref, publicDirectory) {
  * @param {URL} publicDirectory
  * @param {URL} sourceFile
  * @param {URL} targetDirectory
+ * @return {Promise<[string, HashCopiedPath]>}
  */
 export default async function hashCopy(publicDirectory, sourceFile, targetDirectory) {
   const content = await readFile(sourceFile);
   const hash = createHash('sha256')
     .update(content)
     .digest('hex');
-  const originalFilename = sourceFile.pathname.split('/').pop();
+  const originalFilename = sourceFile.pathname.split('/').pop() || '';
   const parts = originalFilename.split('.');
 
   parts[parts.length - 2] = `hashed-${parts[parts.length - 2]}-${hash}`;
@@ -41,11 +62,11 @@ export default async function hashCopy(publicDirectory, sourceFile, targetDirect
 
   await writeFile(target, content);
 
+  const hashedFilePath = target.pathname.slice(publicDirectory.pathname.length - 1);
+  const dependencies = findImports(content.toString(), target, publicDirectory);
+
   return [
     new URL(originalFilename, targetDirectory).pathname.slice(publicDirectory.pathname.length - 1),
-    {
-      hashedFilePath: target.pathname.slice(publicDirectory.pathname.length - 1),
-      dependencies: findImports(content.toString(), target, publicDirectory)
-    }
+    new HashCopiedPath(hashedFilePath, dependencies)
   ];
 }

--- a/lib/load-post-files.js
+++ b/lib/load-post-files.js
@@ -6,43 +6,8 @@ import makeSnippet from './make-snippet.js';
 import checkForRubyAnnotations from './check-for-ruby-annotations.js';
 import render from './render.js';
 import getLocalLinks from './get-local-links.js';
+import generateImportMap from './generate-import-map.js';
 import parseFrontMatter from './parse-front-matter.js';
-
-function generateImportMap(baseUrl, pageUrl, scripts, hashedScripts) {
-  const resolved = new Set();
-  const hrefs = scripts.map(s => s.href);
-  const queue = hrefs.map(href => new URL(href, pageUrl).pathname);
-
-  while (queue.length) {
-    const path = queue.shift();
-
-    if (resolved.has(path)) {
-      continue;
-    }
-
-    const { dependencies = [] } = hashedScripts[path] || {};
-
-    for (const dependency of dependencies) {
-      queue.push(new URL(dependency, new URL(path, baseUrl)).pathname);
-    }
-
-    resolved.add(path);
-  }
-
-  const importMap = { imports: {} };
-  let count = 0;
-
-  for (const url of Array.from(resolved).sort()) {
-    const localHashed = hashedScripts[url];
-
-    if (localHashed && !hrefs.includes(url)) {
-      importMap.imports[url] = localHashed.hashedFilePath;
-      count++;
-    }
-  }
-
-  return count ? importMap : null;
-}
 
 function compareHashedScripts(a, b) {
   const akeys = Object.keys(a);
@@ -80,12 +45,11 @@ async function loadPostFile({ fileUrl, basePath, baseUrl, repoUrl, type, extraCs
   const slug = attributes.slug || createSlug(title);
   const date = new Date(datetime);
   const content = render(body);
-  const { document } = new JSDOM(content).window;
+  const canonical = new URL(`/${type}/${slug}`, baseUrl);
+  const { document } = new JSDOM(content, { url: canonical.href }).window;
   const hasRuby = checkForRubyAnnotations(document);
-  const canonical = `${baseUrl}/${type}/${slug}`;
-  const localLinks = getLocalLinks(document, canonical, baseUrl);
   const allScripts = hasRuby ? scripts.concat({ href: '/scripts/ruby-options.js' }) : scripts;
-  const importMap = generateImportMap(baseUrl, canonical, allScripts, hashedScripts);
+  const importMap = generateImportMap(canonical, allScripts, hashedScripts);
 
   const digested = {
     mtimeMs,
@@ -107,7 +71,7 @@ async function loadPostFile({ fileUrl, basePath, baseUrl, repoUrl, type, extraCs
     slug,
     localUrl: `/${type}/${slug}`,
     canonical,
-    localLinks,
+    localLinks: getLocalLinks(document),
     filename: `${slug}.html`,
     mastodonHandle: '@qubyte@mastodon.social',
     title,


### PR DESCRIPTION
- Move generateImportMap to its own module.
- Refactor getLocalLinks to only take a document object.
- The hashCopy module now also exposes a utility class to contain results.