### PR TITLE
Renders images as picture elements with variants.

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,25 +142,35 @@ export async function build({ baseUrl, baseTitle, repoUrl, dev }) {
       });
     },
     specialFiles: {
-      dependencies: ['extraCss', 'hashedScripts'],
-      async action({ extraCss, hashedScripts }) {
+      dependencies: ['extraCss', 'hashedScripts', 'images'],
+      async action({ extraCss, hashedScripts, images }) {
         const specialPath = new URL('special/', contentPath);
 
         return ExecutionGraph.createWatchableResult({
           path: specialPath,
-          result: await loadPostFiles({ path: specialPath, basePath, repoUrl, baseUrl, extraCss, hashedScripts, type: null })
+          result: await loadPostFiles({ path: specialPath, basePath, repoUrl, baseUrl, extraCss, hashedScripts, type: null, images })
         });
       }
     },
     postFiles: {
-      dependencies: ['extraCss', 'mathStyles', 'codeStyle', 'hashedScripts'],
-      async action({ extraCss, mathStyles, codeStyle, hashedScripts }) {
+      dependencies: ['extraCss', 'mathStyles', 'codeStyle', 'hashedScripts', 'images'],
+      async action({ extraCss, mathStyles, codeStyle, hashedScripts, images }) {
         const postsPath = new URL('posts/', contentPath);
         const joinedStyles = new Map([...extraCss, ...mathStyles, ...codeStyle]);
 
         return ExecutionGraph.createWatchableResult({
           path: postsPath,
-          result: await loadPostFiles({ path: postsPath, basePath, repoUrl, baseUrl, extraCss: joinedStyles, hashedScripts, type: 'blog' })
+          result: await loadPostFiles({
+            path: postsPath,
+            basePath,
+            repoUrl,
+            baseUrl,
+            extraCss:
+            joinedStyles,
+            hashedScripts,
+            type: 'blog',
+            images
+          })
         });
       }
     },
@@ -195,14 +205,14 @@ export async function build({ baseUrl, baseTitle, repoUrl, dev }) {
       }
     },
     japaneseNotesFiles: {
-      dependencies: ['hashedScripts'],
-      async action({ hashedScripts }) {
+      dependencies: ['hashedScripts', 'images'],
+      async action({ hashedScripts, images }) {
         const notesPath = new URL('japanese-notes/', contentPath);
         const type = 'japanese-notes';
 
         return ExecutionGraph.createWatchableResult({
           path: notesPath,
-          result: await loadPostFiles({ path: notesPath, basePath, repoUrl, baseUrl, type, hashedScripts })
+          result: await loadPostFiles({ path: notesPath, basePath, repoUrl, baseUrl, type, hashedScripts, images })
         });
       }
     },
@@ -548,7 +558,8 @@ export async function build({ baseUrl, baseTitle, repoUrl, dev }) {
           dev,
           baseUrl,
           localUrl: '/blog',
-          title: 'Archive'
+          title: 'Archive',
+          description: 'A collection of my long form articles.'
         });
       }
     },
@@ -564,7 +575,8 @@ export async function build({ baseUrl, baseTitle, repoUrl, dev }) {
           dev,
           baseUrl,
           localUrl: '/japanese-notes',
-          title: 'Japanese Study Notes'
+          title: 'Japanese Study Notes',
+          description: 'A collection of notes I\'ve written on the Japanese language, as I study it.'
         });
       }
     },
@@ -578,7 +590,8 @@ export async function build({ baseUrl, baseTitle, repoUrl, dev }) {
           dev,
           baseUrl,
           localUrl: '/notes',
-          title: 'Notes'
+          title: 'Notes',
+          description: 'A collection of my short notes.'
         });
       }
     },
@@ -592,7 +605,8 @@ export async function build({ baseUrl, baseTitle, repoUrl, dev }) {
           dev,
           baseUrl,
           localUrl: '/study-sessions',
-          title: 'Study Sessions'
+          title: 'Study Sessions',
+          description: 'A collection of my study sessions.'
         });
       }
     },
@@ -605,7 +619,8 @@ export async function build({ baseUrl, baseTitle, repoUrl, dev }) {
           dev,
           baseUrl,
           localUrl: '/links',
-          title: 'Links'
+          title: 'Links',
+          description: 'A collection of links to articles elsewhere on the web.'
         });
       }
     },
@@ -618,7 +633,8 @@ export async function build({ baseUrl, baseTitle, repoUrl, dev }) {
           dev,
           baseUrl,
           localUrl: '/likes',
-          title: 'Likes'
+          title: 'Likes',
+          description: 'A collection of likes of articles elsewhere on the web.'
         });
       }
     },
@@ -631,7 +647,8 @@ export async function build({ baseUrl, baseTitle, repoUrl, dev }) {
           dev,
           baseUrl,
           localUrl: '/replies',
-          title: 'Replies'
+          title: 'Replies',
+          description: 'A collection of the replies to articles elsewhere on the web.'
         });
       }
     },
@@ -657,7 +674,8 @@ export async function build({ baseUrl, baseTitle, repoUrl, dev }) {
           baseUrl,
           localUrl: '/publications',
           publications,
-          title: 'Publications'
+          title: 'Publications',
+          description: 'A collection of academic publications I have authored and coauthored.'
         });
       }
     },
@@ -670,7 +688,14 @@ export async function build({ baseUrl, baseTitle, repoUrl, dev }) {
     renderedWebmentionConfirmation: {
       dependencies: ['css', 'templates'],
       action({ templates, css: { cssPath } }) {
-        return templates.webmention({ cssPath, dev, baseUrl, localUrl: '/webmention', title: 'Webmention' });
+        return templates.webmention({
+          cssPath,
+          dev,
+          baseUrl,
+          localUrl: '/webmention',
+          title: 'Webmention',
+          description: 'Your mention is confirmed! Please check back later.'
+        });
       }
     },
     renderedSitemap: {

--- a/lib/build-backlinks.js
+++ b/lib/build-backlinks.js
@@ -1,12 +1,18 @@
+// @ts-check
+
+/** @typedef {import('./load-post-files.js').PostPage} PostPage */
+
+/** @param {PostPage[]} entries */
 export default function buildBacklinks(entries) {
+  /** @type {Record<string, PostPage[]>} */
   const backlinks = {};
 
-  for (const { title, localUrl, localLinks, timestamp } of entries) {
-    for (const href of localLinks) {
+  for (const entry of entries) {
+    for (const href of entry.localLinks) {
       if (!backlinks[href]) {
         backlinks[href] = [];
       }
-      backlinks[href].push({ title, href: localUrl, timestamp });
+      backlinks[href].push(entry);
     }
   }
 

--- a/lib/collate-tags.js
+++ b/lib/collate-tags.js
@@ -23,10 +23,7 @@ export default function collateTags({ posts, cssPath, baseUrl, dev, template }) 
 
   for (const post of posts) {
     for (const tag of post.tags || []) {
-      if (!tags[tag]) {
-        tags[tag] = [];
-      }
-
+      tags[tag] ||= [];
       tags[tag].push(post);
     }
   }

--- a/lib/compose-picture.js
+++ b/lib/compose-picture.js
@@ -1,0 +1,64 @@
+import { extname } from 'node:path';
+import handlebars from 'handlebars';
+
+const makePicture = handlebars.compile(`
+  {{#if caption}}<figure>{{/if}}
+  <picture>
+    {{#each sources}}
+    <source type="{{mime}}" srcset="{{srcset}}">
+    {{/each}}
+    <img class="u-photo" src="{{src}}" alt="{{alt}}" width="{{width}}" height="{{height}}" loading="lazy">
+  </picture>
+  {{#if caption}}
+  <figcaption>{{caption}}</figcaption>
+  </figure>
+  {{/if}}
+`);
+
+const scaleRegex = /-(?<scale>\d+)x\./;
+
+/**
+ * @param {string} url
+ * @param {string|null} caption
+ * @param {string} alt
+ * @param {Map<string, { width: number, height: number }>} imagesMap
+ */
+export default function composePicture(url, caption, alt, imagesMap) {
+  const dimensions = imagesMap.get(url);
+
+  if (!dimensions) {
+    throw new Error(`Unknown image: ${url}`);
+  }
+
+  const { width, height } = dimensions;
+
+  const extless = url.slice(0, -extname(url).length);
+
+  /** @type Record<string, { ratio: number, path: string }[]> */
+  const sources = {};
+
+  for (const urlPath of imagesMap.keys()) {
+    if (urlPath.startsWith(extless) && urlPath !== url && !urlPath.includes('original')) {
+      const mime = `image/${extname(urlPath).slice(1)}`;
+      const scaleMatch = urlPath.match(scaleRegex);
+      const ratio = Number(scaleMatch?.groups?.scale || 1);
+
+      sources[mime] ||= [];
+      sources[mime].push({ ratio, path: urlPath });
+    }
+  }
+
+  const sourcesList = Object
+    .entries(sources)
+    .toSorted((a, b) => a[0] < b[0] ? 1 : -1)
+    .map(([mime, urlPaths]) => {
+      const srcset = urlPaths
+        .toSorted((a, b) => a.ratio - b.ratio)
+        .map(({ ratio, path }) => ratio === 1 ? path : `${path} ${ratio}x`)
+        .join(', ');
+
+      return { mime, srcset };
+    });
+
+  return makePicture({ sources: sourcesList, width, height, alt, src: url, caption }).trim();
+}

--- a/lib/load-note-files.js
+++ b/lib/load-note-files.js
@@ -2,6 +2,7 @@ import { readdir, readFile } from 'node:fs/promises';
 import render from './render.js';
 import getTimezone from './get-timezone.js';
 import Page from './page.js';
+import composePicture from './compose-picture.js';
 
 class NotePage extends Page {
   /**
@@ -53,27 +54,9 @@ export default async function loadNoteFiles({ baseUrl, dir, imagesDimensions }) 
     const content = render(note.content);
 
     const photos = await Promise.all((note.photo ? [].concat(note.photo) : []).map(p => {
-      const photo = typeof p === 'string' ? { value: p, alt: note.content } : { ...p };
-      const name = photo.value.match(/\/(?<name>\d+)\./)?.groups.name;
-      const { width, height } = imagesDimensions.get(photo.value);
+      const { value, alt } = typeof p === 'string' ? { value: p, alt: note.content } : { ...p };
 
-      photo.width = width;
-      photo.height = height;
-
-      if (imagesDimensions.get(`/images/${name}.avif`)) {
-        photo.avif = `/images/${name}.avif`;
-      }
-      if (imagesDimensions.get(`/images/${name}-2x.avif`)) {
-        photo.avif2x = `/images/${name}-2x.avif`;
-      }
-      if (imagesDimensions.get(`/images/${name}.webp`)) {
-        photo.webp = `/images/${name}.webp`;
-      }
-      if (imagesDimensions.get(`/images/${name}-2x.webp`)) {
-        photo.webp2x = `/images/${name}-2x.webp`;
-      }
-
-      return photo;
+      return composePicture(value, null, alt, imagesDimensions);
     }));
 
     return new NotePage({

--- a/lib/load-post-files.js
+++ b/lib/load-post-files.js
@@ -45,7 +45,7 @@ function getCached({ fileUrl, mtimeMs, extraCss, hashedScripts }) {
   return null;
 }
 
-class PostPage extends Page {
+export class PostPage extends Page {
   /**
    * @param {object} options
    * @param {string|URL} options.baseUrl
@@ -142,7 +142,7 @@ class PostPage extends Page {
   }
 }
 
-async function loadPostFile({ fileUrl, basePath, baseUrl, repoUrl, type, extraCss, hashedScripts }) {
+async function loadPostFile({ fileUrl, basePath, baseUrl, repoUrl, type, extraCss, hashedScripts, images }) {
   const { mtimeMs } = await stat(fileUrl, { bigint: true });
   const cached = getCached({ fileUrl, mtimeMs, extraCss, hashedScripts });
 
@@ -155,7 +155,7 @@ async function loadPostFile({ fileUrl, basePath, baseUrl, repoUrl, type, extraCs
   const { title, datetime, updatedAt, tags, webmentions, draft, description, scripts = [], styles = [] } = attributes;
   const slug = attributes.slug || createSlug(title);
   const localUrl = type ? `/${type}/${slug}` : `/${slug}`;
-  const content = await render(body);
+  const content = render(body, images);
   const editUrl = `${repoUrl}/edit/main/${fileUrl.href.slice(basePath.href.length)}`; // Assumes GitHub and main branch.
 
   const digested = new PostPage({
@@ -193,7 +193,8 @@ export default async function loadPostFiles({
   baseUrl,
   type,
   extraCss = new Map(),
-  hashedScripts
+  hashedScripts,
+  images
 }) {
   const filenames = await readdir(path);
   const posts = await Promise.all(filenames.map(fn => loadPostFile({
@@ -203,7 +204,8 @@ export default async function loadPostFiles({
     repoUrl,
     type,
     extraCss,
-    hashedScripts
+    hashedScripts,
+    images
   })));
   const now = Date.now();
 

--- a/lib/render.js
+++ b/lib/render.js
@@ -4,6 +4,7 @@ import { gfmHeadingId } from 'marked-gfm-heading-id';
 import { markedHighlight } from 'marked-highlight';
 import temml from 'temml/dist/temml.mjs';
 import { JSDOM } from 'jsdom';
+import composePicture from './compose-picture.js';
 
 /**
  * The lang-span markdown extension introduces spans with language attributes.
@@ -77,6 +78,11 @@ marked.use(
   }),
   {
     mangle: false,
+    renderer: {
+      image(href, title, text) {
+        return href?.trim() ? composePicture(href, title, text, this.options.imagesMap) : text;
+      }
+    },
     extensions: [
       {
         name: 'lang-span',
@@ -309,4 +315,12 @@ marked.use(
   }
 );
 
-export default marked;
+/**
+ * @param {string} input
+ * @param {Map<string, { width: number, height: number }>} imagesMap
+ * @returns {string}
+ */
+export default function render(input, imagesMap) {
+  return marked(input, { async: false, imagesMap });
+}
+

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -260,6 +260,13 @@ img {
   box-sizing: border-box;
 }
 
+figcaption {
+  width: calc(100% - 2em);
+  font-size: 0.75rem;
+  margin: 1em 1em;
+  line-height: 1.5em;
+}
+
 select {
   background-color: var(--background-color-main);
   color: var(--standout-color-main);

--- a/src/templates/partials/backlinks.html.handlebars
+++ b/src/templates/partials/backlinks.html.handlebars
@@ -3,7 +3,7 @@
   <h3>Backlinks</h3>
   <ul>
     {{#backlinks}}
-    <li><a class="backlink" href="{{href}}">{{title}}</a></li>
+    <li><a class="backlink" href="{{localUrl}}">{{title}}</a></li>
     {{/backlinks}}
   </ul>
 </section>

--- a/src/templates/partials/note.html.handlebars
+++ b/src/templates/partials/note.html.handlebars
@@ -7,12 +7,6 @@
   <div class="e-content">
     {{{content}}}
   </div>
-  {{#photos}}
-    <picture>
-      {{#if avif}}<source type="image/avif" srcset="{{avif}}{{#if avif2x}}, {{avif2x}} 2x{{/if}}">{{/if}}
-      {{#if webp}}<source type="image/webp" srcset="{{webp}}{{#if webp2x}}, {{webp2x}} 2x{{/if}}">{{/if}}
-      <img class="u-photo" src="{{value}}" alt="{{alt}}" width="{{width}}" height="{{height}}" loading="lazy">
-    </picture>
-  {{/photos}}
+  {{#each photos}}{{{this}}}{{/each}}
   {{#if spoiler}}</details>{{/if}}
 </article>


### PR DESCRIPTION
The idea here is to repurpose the markdown image syntax to provide better image rendering. Given an image path, the renderer will find all variants (including scale variants and type variants) and render a picture element with sources so that the browser can choose which it judges to be the best variant. When a title is provided, it will be further wrapped in a figure and a figure caption added.