### PR TITLE
Overhaul the execution graph API.

### DIFF
--- a/lib/execution-graph.js
+++ b/lib/execution-graph.js
@@ -1,70 +1,107 @@
 import { EventEmitter, once } from 'node:events';
 
-async function waitForDependencies(executionGraph, dependencies) {
-  const results = {};
-
-  await Promise.all(dependencies.map(async name => {
-    let dependecyNode = executionGraph.nodes.get(name);
-
-    if (!dependecyNode || !dependecyNode.done) {
-      ([dependecyNode] = await once(executionGraph, `done:${name}`));
-    }
-
-    results[name] = dependecyNode.result;
-  }));
-
-  return results;
-}
-
-async function watchForChanges(watcher, graph) {
-  for await (const { url } of watcher) {
-    for (const [name, { watchPath }] of graph.nodes) {
-      if (watchPath && url.pathname.startsWith(watchPath.pathname)) {
-        console.time(`Build succeeded for ${name}`); // eslint-disable-line no-console
-        console.log('Rerunning Node:', name); // eslint-disable-line no-console
-        try {
-          graph.rerunNode({ name });
-        } catch (e) {
-          console.error('BUILD ERROR:', e.stack); // eslint-disable-line no-console
-        }
-        console.timeEnd(`Build succeeded for ${name}`); // eslint-disable-line no-console
-      }
-    }
-  }
-}
-
-class WatchableResult {
+export class WatchableResult {
+  /** @param {{ path: string, result: any }} options */
   constructor({ path, result }) {
     this.path = path;
     this.result = result;
   }
 }
 
+export class GraphNode {
+  /**
+   * @param {object} options
+   * @param {string} options.name
+   * @param {Function} options.action
+   * @param {Function?} options.onRemove
+   * @param {string[]?} options.dependencies
+   */
+  constructor({ name, action, onRemove, dependencies = [] }) {
+    this.done = false;
+    this.name = name;
+    this.action = action;
+    this.onRemove = onRemove;
+    this.dependencies = dependencies;
+    this.result = null;
+    /** @type {string|null} */
+    this.watchPath = null;
+  }
+}
+
 export default class ExecutionGraph extends EventEmitter {
+  /**
+   * @param {Object} options
+   * @param {ExecutionGraph} options.parent
+   * @param {AsyncGenerator<{eventType: string, url: URL}>|null} options.watcher
+   */
   constructor({ parent, watcher } = {}) {
     super();
 
     this.parent = parent;
+    /** @type {Map<string, GraphNode>} */
     this.nodes = new Map();
     this.setMaxListeners(0);
 
     if (watcher) {
-      watchForChanges(watcher, this);
+      this.#watchForChanges(watcher, this);
     }
   }
 
-  async addNode({ name, action, onRemove, dependencies = [] }) {
-    const node = { action, onRemove, dependencies, done: false };
+  /** @param {AsyncGenerator<{eventType: string, url: URL}>} watcher */
+  async #watchForChanges(watcher) {
+    for await (const { url } of watcher) {
+      for (const [name, { watchPath }] of this.nodes) {
+        if (watchPath && url.pathname.startsWith(watchPath.pathname)) {
+          console.time(`Build succeeded for ${name}`); // eslint-disable-line no-console
+          console.log('Rerunning Node:', name); // eslint-disable-line no-console
+          try {
+            this.rerunNode(name);
+          } catch (e) {
+            console.error('BUILD ERROR:', e.stack); // eslint-disable-line no-console
+          }
+          console.timeEnd(`Build succeeded for ${name}`); // eslint-disable-line no-console
+        }
+      }
+    }
+  }
 
-    if (dependencies.includes(name)) {
+  /** @param {string[]} dependencies */
+  async #waitForDependencies(dependencies) {
+    /** @type {Record<string, any>} */
+    const results = {};
+
+    await Promise.all(dependencies.map(async name => {
+      let dependecyNode = this.nodes.get(name);
+
+      if (!dependecyNode || !dependecyNode.done) {
+        ([dependecyNode] = await once(this, `done:${name}`));
+      }
+
+      results[name] = dependecyNode.result;
+    }));
+
+    return results;
+  }
+
+  // /**
+  //  * @param {Object} options
+  //  * @param {string} options.name
+  //  * @param {Function} options.action
+  //  * @param {Function|undefined} options.onRemove
+  //  * @param {string[]} options.dependencies
+  //  */
+  /** @param {GraphNode|Function} node */
+  async addNode(rawNode) {
+    const node = rawNode instanceof GraphNode ? rawNode : new GraphNode({ name: rawNode.name, action: rawNode });
+
+    if (node.dependencies.includes(node.name)) {
       throw new Error('Node may not depend on itself.');
     }
 
-    this.nodes.set(name, node);
+    this.nodes.set(node.name, node);
 
-    const dependencyResults = await waitForDependencies(this, dependencies);
-
-    const result = await action(dependencyResults);
+    const dependencyResults = await this.#waitForDependencies(node.dependencies);
+    const result = await node.action(dependencyResults);
 
     if (result instanceof WatchableResult) {
       node.result = result.result;
@@ -75,33 +112,33 @@ export default class ExecutionGraph extends EventEmitter {
 
     node.done = true;
 
-    this.emit(`done:${name}`, node);
-    this.emit('done', name, node);
+    this.emit(`done:${node.name}`, node);
+    this.emit('done', node.name, node);
 
     return node.result;
   }
 
-  addNodes(nodes) {
-    const graph = this;
+  /** @param {(GraphNode|Function)[]} nodes */
+  async addNodes(nodes) {
+    const promises = [];
 
-    async function processNode([name, spec]) {
-      let action;
-      let onRemove;
-      let dependencies;
+    /** @type {Record<string, any>} */
+    const results = {};
 
-      if (typeof spec === 'function') {
-        action = spec;
-      } else {
-        ({ action, onRemove, dependencies } = spec);
-      }
-
-      return [name, await graph.addNode({ name, action, onRemove, dependencies })];
+    for (const node of nodes) {
+      promises.push(
+        this.addNode(node).then(r => {
+          results[node.name] = r;
+        })
+      );
     }
 
-    return Promise.all(Object.entries(nodes).map(processNode)).then(Object.fromEntries);
+    await Promise.all(promises);
+
+    return results;
   }
 
-  async removeNode({ name }) {
+  async removeNode(name) {
     const node = this.nodes.get(name);
 
     if (!node) {
@@ -127,8 +164,12 @@ export default class ExecutionGraph extends EventEmitter {
     this.nodes.delete(name);
   }
 
-  // Inversion! Given a node, which nodes directly depend on it?
-  getDirectDependents({ name }) {
+  /**
+   * Inversion! Given a node, which nodes directly depend on it?
+   *
+   * @param {string} name
+   */
+  getDirectDependents(name) {
     const dependents = [];
 
     for (const [nodeName, { dependencies }] of this.nodes) {
@@ -140,37 +181,36 @@ export default class ExecutionGraph extends EventEmitter {
     return dependents;
   }
 
-  // rerunning a node amounts to finding the subtree which depends on it,
-  // removing its nodes, and re-adding them.
-  // TODO: This is very clunky. There's probably a more elegant way.
-  // eslint-disable-next-line max-statements
-  async rerunNode({ name }) {
+  /**
+   * rerunning a node amounts to finding the subtree which depends on it,
+   * removing its nodes, and re-adding them.
+   *
+   * @todo This is very clunky. There's probably a more elegant way.
+   *
+   * @param {string} name
+   */
+  async rerunNode(name) {
     const node = this.nodes.get(name);
-    const dependents = this.getDirectDependents({ name });
+
+    if (!node) {
+      return;
+    }
+
+    const dependents = this.getDirectDependents(name);
     const collected = new Map([[name, { node, dependents }]]);
 
-    let oldSize;
-    let newSize;
-
-    // Collect the tree of nodes dependent on the targeted node.
-    do {
-      oldSize = collected.size;
-
+    for (let oldSize = collected.size, newSize = 0; newSize !== oldSize; newSize = oldSize, oldSize = collected.size) {
       for (const { dependents } of collected.values()) {
         for (const name of dependents) {
           if (!collected.has(name)) {
             const node = this.nodes.get(name);
-            collected.set(name, {
-              node,
-              dependents: this.getDirectDependents({ name })
-            });
+            collected.set(name, { node, dependents: this.getDirectDependents(name) });
           }
         }
       }
+    }
 
-      newSize = collected.size;
-    } while (oldSize !== newSize);
-
+    /** @type {Set<string>} */
     const removed = new Set();
 
     // Remove the nodes, starting with leaves.
@@ -187,16 +227,18 @@ export default class ExecutionGraph extends EventEmitter {
     await Promise.all([...collected].map(([, { node }]) => node.onRemove && node.onRemove()));
 
     // Re-add the nodes.
-    const results = await Promise.all(
-      [...collected].map(([name, { node: { action, onRemove, dependencies } }]) => this.addNode({ name, action, onRemove, dependencies }))
+    await Promise.all(
+      [...collected].map(([
+        name,
+        { node: { action, onRemove, dependencies } }
+      ]) => this.addNode(new GraphNode({ name, action, onRemove, dependencies })))
     );
 
     this.emit('rerun');
-
-    return results;
   }
 
   get results() {
+    /** @type {Record<string, any>} */
     const results = {};
 
     for (const [key, { result, done }] of this.nodes) {
@@ -206,9 +248,5 @@ export default class ExecutionGraph extends EventEmitter {
     }
 
     return results;
-  }
-
-  static createWatchableResult({ path, result }) {
-    return new WatchableResult({ path, result });
   }
 }


### PR DESCRIPTION
There's still more to do here. I think I can drop using string names completely, and have graph nodes directly refer to each other by reference. The `GraphNode` context could be populated with the names and resolved return values of its dependencies. It's _probably_ possible to fully type everything this way with only JSDoc annotations.